### PR TITLE
Remove Windows abstraction.

### DIFF
--- a/cmd/examples/hello-world/main.go
+++ b/cmd/examples/hello-world/main.go
@@ -9,8 +9,8 @@ func main() {
 	opengl.StartMainThreadLoop(func(loop *opengl.MainThreadLoop) {
 		gl := opengl.New(loop)
 		images := pixiq.NewImages(gl.AcceleratedImages())
-		windows := pixiq.NewWindows(images, gl.SystemWindows())
-		windows.New(320, 16).Loop(func(frame *pixiq.Frame) {
+		window := gl.Windows().Open(320, 16)
+		pixiq.NewWindows(images).Loop(window, func(frame *pixiq.Frame) {
 			screen := frame.Image().WholeImageSelection()
 			red := pixiq.RGBA(255, 0, 0, 255)
 			screen.SetColor(4, 4, red)

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -111,7 +111,7 @@ type window struct {
 func (g *window) Draw(image *pixiq.Image) {
 	texture, isGL := image.Upload().(GLTexture)
 	if !isGL {
-		panic("opengl Windows implementation can only draw images accelerated with opengl.GLTexture")
+		panic("opengl Window implementation can only draw images accelerated with opengl.GLTexture")
 	}
 	g.mainThreadLoop.Execute(func() {
 		g.program.use()

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -72,11 +72,11 @@ type Windows struct {
 
 // Open creates and show window
 func (g Windows) Open(width, height int, hints ...WindowHint) pixiq.Window {
-	if width < 0 {
-		width = 0
+	if width < 1 {
+		width = 1
 	}
-	if height < 0 {
-		height = 0
+	if height < 1 {
+		height = 1
 	}
 	frameImagePolygon := newFrameImagePolygon(g.mainThreadLoop, g.program.vertexPositionLocation, g.program.texturePositionLocation)
 	g.mainThreadLoop.Execute(func() {

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -7,7 +7,8 @@ import (
 	"github.com/jacekolszak/pixiq"
 )
 
-// New creates OpenGL instance providing implementations of both AcceleratedImages and SystemWindows.
+// New creates OpenGL instance providing implementation of AcceleratedImages and Windows for opening system windows.
+// Under the hood it is using OpenGL API and GLFW for manipulating windows and handling user input.
 // MainThreadLoop is needed because some GLFW functions has to be called from main thread.
 func New(loop *MainThreadLoop) *OpenGL {
 	var program *program
@@ -38,7 +39,7 @@ func New(loop *MainThreadLoop) *OpenGL {
 	})
 	return &OpenGL{
 		textures: &textures{mainThreadLoop: loop},
-		glfwWindows: &glfwWindows{
+		windows: &Windows{
 			window:         window,
 			program:        program,
 			mainThreadLoop: loop,
@@ -46,10 +47,10 @@ func New(loop *MainThreadLoop) *OpenGL {
 	}
 }
 
-// OpenGL provides opengl implementations of AcceleratedImages and SystemWindows
+// OpenGL provides opengl implementations of AcceleratedImages. It also provides Windows for opening system windows
 type OpenGL struct {
-	textures    *textures
-	glfwWindows *glfwWindows
+	textures *textures
+	windows  *Windows
 }
 
 // AcceleratedImages returns opengl implementation of AcceleratedImages
@@ -57,54 +58,54 @@ func (g OpenGL) AcceleratedImages() pixiq.AcceleratedImages {
 	return g.textures
 }
 
-// SystemWindows returns opengl implementation of SystemWindows
-func (g OpenGL) SystemWindows() pixiq.SystemWindows {
-	return g.glfwWindows
+// Windows returns object for opening system windows
+func (g OpenGL) Windows() *Windows {
+	return g.windows
 }
 
-type glfwWindows struct {
+// Windows is for opening system windows
+type Windows struct {
 	program        *program
 	mainThreadLoop *MainThreadLoop
 	window         *glfw.Window
 }
 
-func (g glfwWindows) Open(width, height int, hints ...pixiq.WindowHint) pixiq.SystemWindow {
+// Open creates and show window
+func (g Windows) Open(width, height int, hints ...WindowHint) pixiq.Window {
 	frameImagePolygon := newFrameImagePolygon(g.mainThreadLoop, g.program.vertexPositionLocation, g.program.texturePositionLocation)
 	g.mainThreadLoop.Execute(func() {
 		for _, hint := range hints {
-			glHint, ok := hint.(openglWindowHint)
-			if ok {
-				glHint.apply(g.window)
-			}
+			hint.apply(g.window)
 		}
 		g.window.SetSize(width, height)
 		g.window.Show()
 	})
-	return &glfwWindow{window: g.window, program: g.program, mainThreadLoop: g.mainThreadLoop, frameImagePolygon: frameImagePolygon}
+	return &window{window: g.window, program: g.program, mainThreadLoop: g.mainThreadLoop, frameImagePolygon: frameImagePolygon}
 }
 
-type openglWindowHint interface {
+// WindowHint is a hint which may (or may not) be applied to window (depending on operating system and other factors).
+type WindowHint interface {
 	apply(window *glfw.Window)
 }
 
-// NoDecorated is window hint hiding the window's titlebar
+// NoDecorated is window hint hiding the window's title bar
 type NoDecorated struct{}
 
 func (NoDecorated) apply(window *glfw.Window) {
 	window.SetAttrib(glfw.Decorated, glfw.False)
 }
 
-type glfwWindow struct {
+type window struct {
 	window            *glfw.Window
 	program           *program
 	mainThreadLoop    *MainThreadLoop
 	frameImagePolygon *frameImagePolygon
 }
 
-func (g *glfwWindow) Draw(image *pixiq.Image) {
+func (g *window) Draw(image *pixiq.Image) {
 	texture, isGL := image.Upload().(GLTexture)
 	if !isGL {
-		panic("opengl SystemWindows implementation can only draw images accelerated with opengl.GLTexture")
+		panic("opengl Windows implementation can only draw images accelerated with opengl.GLTexture")
 	}
 	g.mainThreadLoop.Execute(func() {
 		g.program.use()
@@ -115,17 +116,27 @@ func (g *glfwWindow) Draw(image *pixiq.Image) {
 	})
 }
 
-func (g *glfwWindow) SwapImages() {
+func (g *window) SwapImages() {
 	g.mainThreadLoop.Execute(func() {
 		g.window.SwapBuffers()
 		glfw.PollEvents()
 	})
 }
 
-func (g *glfwWindow) Close() {
+func (g *window) Close() {
 	g.mainThreadLoop.Execute(func() {
 		g.window.Destroy()
 	})
+}
+
+func (g *window) Width() int {
+	w, _ := g.window.GetSize()
+	return w
+}
+
+func (g *window) Height() int {
+	_, h := g.window.GetSize()
+	return h
 }
 
 type textures struct {

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -72,6 +72,12 @@ type Windows struct {
 
 // Open creates and show window
 func (g Windows) Open(width, height int, hints ...WindowHint) pixiq.Window {
+	if width < 0 {
+		width = 0
+	}
+	if height < 0 {
+		height = 0
+	}
 	frameImagePolygon := newFrameImagePolygon(g.mainThreadLoop, g.program.vertexPositionLocation, g.program.texturePositionLocation)
 	g.mainThreadLoop.Execute(func() {
 		for _, hint := range hints {

--- a/opengl/opengl_test.go
+++ b/opengl/opengl_test.go
@@ -1,6 +1,7 @@
 package opengl_test
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 
@@ -94,13 +95,30 @@ func TestTexture_Upload(t *testing.T) {
 }
 
 func TestGlfwWindows_Open(t *testing.T) {
+	t.Run("should clamp width to 0 if negative", func(t *testing.T) {
+		openGL := opengl.New(mainThreadLoop)
+		windows := openGL.Windows()
+		// when
+		win := windows.Open(-1, 0)
+		require.NotNil(t, win)
+		assert.Equal(t, 0, win.Width())
+	})
+	t.Run("should clamp height to 0 if negative", func(t *testing.T) {
+		openGL := opengl.New(mainThreadLoop)
+		windows := openGL.Windows()
+		// when
+		win := windows.Open(0, -1)
+		require.NotNil(t, win)
+		assert.Equal(t, 0, win.Height())
+	})
 	t.Run("should open window", func(t *testing.T) {
 		openGL := opengl.New(mainThreadLoop)
 		windows := openGL.Windows()
 		// when
-		window := windows.Open(640, 360)
-		// then
-		assert.NotNil(t, window)
+		win := windows.Open(1, 2)
+		require.NotNil(t, win)
+		assert.Equal(t, 1, win.Width())
+		assert.Equal(t, 2, win.Height())
 	})
 }
 

--- a/opengl/opengl_test.go
+++ b/opengl/opengl_test.go
@@ -95,21 +95,21 @@ func TestTexture_Upload(t *testing.T) {
 }
 
 func TestGlfwWindows_Open(t *testing.T) {
-	t.Run("should clamp width to 0 if negative", func(t *testing.T) {
+	t.Run("should clamp width to 1 if negative", func(t *testing.T) {
 		openGL := opengl.New(mainThreadLoop)
 		windows := openGL.Windows()
 		// when
 		win := windows.Open(-1, 0)
 		require.NotNil(t, win)
-		assert.Equal(t, 0, win.Width())
+		assert.Equal(t, 1, win.Width())
 	})
-	t.Run("should clamp height to 0 if negative", func(t *testing.T) {
+	t.Run("should clamp height to 1 if negative", func(t *testing.T) {
 		openGL := opengl.New(mainThreadLoop)
 		windows := openGL.Windows()
 		// when
 		win := windows.Open(0, -1)
 		require.NotNil(t, win)
-		assert.Equal(t, 0, win.Height())
+		assert.Equal(t, 1, win.Height())
 	})
 	t.Run("should open window", func(t *testing.T) {
 		openGL := opengl.New(mainThreadLoop)

--- a/opengl/opengl_test.go
+++ b/opengl/opengl_test.go
@@ -27,7 +27,7 @@ func TestNew(t *testing.T) {
 		// when
 		openGL := opengl.New(mainThreadLoop)
 		images := openGL.AcceleratedImages()
-		windows := openGL.SystemWindows()
+		windows := openGL.Windows()
 		// then
 		assert.NotNil(t, images)
 		assert.NotNil(t, windows)
@@ -96,7 +96,7 @@ func TestTexture_Upload(t *testing.T) {
 func TestGlfwWindows_Open(t *testing.T) {
 	t.Run("should open window", func(t *testing.T) {
 		openGL := opengl.New(mainThreadLoop)
-		windows := openGL.SystemWindows()
+		windows := openGL.Windows()
 		// when
 		window := windows.Open(640, 360)
 		// then
@@ -113,7 +113,7 @@ func TestGlfwWindow_Draw(t *testing.T) {
 
 		t.Run("1x1", func(t *testing.T) {
 			openGL := opengl.New(mainThreadLoop)
-			windows := openGL.SystemWindows()
+			windows := openGL.Windows()
 			window := windows.Open(1, 1, opengl.NoDecorated{})
 			images := pixiq.NewImages(openGL.AcceleratedImages())
 			image := images.New(1, 1)
@@ -125,7 +125,7 @@ func TestGlfwWindow_Draw(t *testing.T) {
 		})
 		t.Run("1x2", func(t *testing.T) {
 			openGL := opengl.New(mainThreadLoop)
-			windows := openGL.SystemWindows()
+			windows := openGL.Windows()
 			window := windows.Open(1, 2, opengl.NoDecorated{})
 			images := pixiq.NewImages(openGL.AcceleratedImages())
 			image := images.New(1, 2)
@@ -138,7 +138,7 @@ func TestGlfwWindow_Draw(t *testing.T) {
 		})
 		t.Run("2x1", func(t *testing.T) {
 			openGL := opengl.New(mainThreadLoop)
-			windows := openGL.SystemWindows()
+			windows := openGL.Windows()
 			window := windows.Open(2, 1, opengl.NoDecorated{})
 			images := pixiq.NewImages(openGL.AcceleratedImages())
 			image := images.New(2, 1)
@@ -151,7 +151,7 @@ func TestGlfwWindow_Draw(t *testing.T) {
 		})
 		t.Run("2x2", func(t *testing.T) {
 			openGL := opengl.New(mainThreadLoop)
-			windows := openGL.SystemWindows()
+			windows := openGL.Windows()
 			window := windows.Open(2, 2, opengl.NoDecorated{})
 			images := pixiq.NewImages(openGL.AcceleratedImages())
 			image := images.New(2, 2)

--- a/windows.go
+++ b/windows.go
@@ -19,6 +19,7 @@ type Window interface {
 	Height() int
 }
 
+// Windows is an abstraction for interaction with windows in a platform-agnostic way
 type Windows struct {
 	images *Images
 }

--- a/windows.go
+++ b/windows.go
@@ -1,81 +1,36 @@
 package pixiq
 
 // NewWindows returns a factory of Window objects.
-func NewWindows(images *Images, windows SystemWindows) *Windows {
-	return &Windows{images: images, systemWindows: windows}
+func NewWindows(images *Images) *Windows {
+	return &Windows{images: images}
 }
 
-// SystemWindows is an API for creating system windows
-type SystemWindows interface {
-	// Open creates and show system window
-	Open(width, height int, hints ...WindowHint) SystemWindow
-}
-
-// SystemWindow is an operating system window
-type SystemWindow interface {
+// Window is a window where images can be drawn
+type Window interface {
 	// Draw draws image spanning the whole window. If double buffering is used it may draw to the invisible buffer.
 	Draw(image *Image)
 	// SwapImages makes last drawn image visible (if double buffering was used, otherwise it may be a no-op)
 	SwapImages()
 	// Close closes the window and cleans resources
 	Close()
+	// Width returns the width of the window in pixels. If zooming is used the width is not multiplied by zoom.
+	Width() int
+	// Height returns the height of the window in pixels. If zooming is used the height is not multiplied by zoom.
+	Height() int
 }
 
-// Windows is a factory of Window objects
 type Windows struct {
-	images        *Images
-	systemWindows SystemWindows
-}
-
-// WindowHint is a window's hint which may (or may not) by applied to window depending on the operating system
-type WindowHint interface {
-}
-
-// New creates a new window with width and height given in pixels.
-func (w *Windows) New(width, height int, hints ...WindowHint) *Window {
-	if width < 0 {
-		width = 0
-	}
-	if height < 0 {
-		height = 0
-	}
-	return &Window{
-		width:         width,
-		height:        height,
-		image:         w.images.New(width, height),
-		systemWindows: w.systemWindows,
-		hints:         hints,
-	}
-}
-
-// Window is area where image will be drawn
-type Window struct {
-	width         int
-	height        int
-	image         *Image
-	systemWindows SystemWindows
-	hints         []WindowHint
-}
-
-// Width returns width of the window in pixels
-func (w *Window) Width() int {
-	return w.width
-}
-
-// Height returns height of the window in pixels
-func (w *Window) Height() int {
-	return w.height
+	images *Images
 }
 
 // Loop starts the main loop. It will execute onEachFrame function for each frame, as soon as window is closed. This
 // function blocks the current goroutine.
-func (w *Window) Loop(onEachFrame func(frame *Frame)) {
-	window := w.systemWindows.Open(w.width, w.height, w.hints...)
+func (w *Windows) Loop(window Window, onEachFrame func(frame *Frame)) {
 	frame := &Frame{}
-	frame.image = w.image
+	frame.image = w.images.New(window.Width(), window.Height())
 	for !frame.closeWindow {
 		onEachFrame(frame)
-		window.Draw(w.image)
+		window.Draw(frame.image)
 		window.SwapImages()
 	}
 	window.Close()

--- a/windows.go
+++ b/windows.go
@@ -1,8 +1,13 @@
 package pixiq
 
-// NewWindows returns a factory of Window objects.
+// NewWindows returns a new instance of Windows
 func NewWindows(images *Images) *Windows {
 	return &Windows{images: images}
+}
+
+// Windows is an abstraction for interaction with windows in a platform-agnostic way
+type Windows struct {
+	images *Images
 }
 
 // Window is a window where images can be drawn
@@ -17,11 +22,6 @@ type Window interface {
 	Width() int
 	// Height returns the height of the window in pixels. If zooming is used the height is not multiplied by zoom.
 	Height() int
-}
-
-// Windows is an abstraction for interaction with windows in a platform-agnostic way
-type Windows struct {
-	images *Images
 }
 
 // Loop starts the main loop. It will execute onEachFrame function for each frame, as soon as window is closed. This

--- a/windows_test.go
+++ b/windows_test.go
@@ -10,81 +10,20 @@ import (
 )
 
 func TestNewWindows(t *testing.T) {
-	t.Run("should return Windows object for creating windows", func(t *testing.T) {
-		windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}), &systemWindowsMock{})
+	t.Run("should return Windows object", func(t *testing.T) {
+		windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}))
 		assert.NotNil(t, windows)
 	})
-}
-
-func TestWindow_New(t *testing.T) {
-	windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}), &systemWindowsMock{})
-	t.Run("should clamp width to 0 if negative", func(t *testing.T) {
-		win := windows.New(-1, 0)
-		require.NotNil(t, win)
-		assert.Equal(t, 0, win.Width())
-	})
-	t.Run("should clamp height to 0 if negative", func(t *testing.T) {
-		win := windows.New(0, -1)
-		require.NotNil(t, win)
-		assert.Equal(t, 0, win.Height())
-	})
-	t.Run("should create window", func(t *testing.T) {
-		win := windows.New(1, 2)
-		require.NotNil(t, win)
-		assert.Equal(t, 1, win.Width())
-		assert.Equal(t, 2, win.Height())
-	})
-	t.Run("New should not open the system window", func(t *testing.T) {
-		systemWindows := &systemWindowsMock{}
-		windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}), systemWindows)
-		// when
-		windows.New(0, 0)
-		// then
-		assert.Empty(t, systemWindows.openWindows)
-	})
-	t.Run("should pass hints to system window", func(t *testing.T) {
-		t.Run("one hint", func(t *testing.T) {
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}), systemWindows)
-			hint := &fakeHint{}
-			// when
-			windows.New(0, 0, hint).Loop(func(frame *pixiq.Frame) {
-				frame.CloseWindowEventually()
-			})
-			// then
-			require.Len(t, systemWindows.openWindows[0].hints, 1)
-			assert.Same(t, hint, systemWindows.openWindows[0].hints[0].(*fakeHint))
-		})
-		t.Run("two hints", func(t *testing.T) {
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(pixiq.NewImages(&fakeAcceleratedImages{}), systemWindows)
-			hint1 := &fakeHint{}
-			hint2 := &fakeHint{}
-			// when
-			windows.New(0, 0, hint1, hint2).Loop(func(frame *pixiq.Frame) {
-				frame.CloseWindowEventually()
-			})
-			// then
-			window := systemWindows.openWindows[0]
-			require.Len(t, window.hints, 2)
-			assert.Same(t, hint1, window.hints[0].(*fakeHint))
-			assert.Same(t, hint2, window.hints[1].(*fakeHint))
-		})
-	})
-}
-
-type fakeHint struct {
 }
 
 func TestWindow_Loop(t *testing.T) {
 
 	t.Run("should run callback function until window is closed", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		windows := pixiq.NewWindows(images, &systemWindowsMock{})
-		window := windows.New(0, 0)
+		windows := pixiq.NewWindows(images)
 		frameNumber := 0
 		// when
-		window.Loop(func(frame *pixiq.Frame) {
+		windows.Loop(&windowMock{}, func(frame *pixiq.Frame) {
 			if frameNumber == 2 {
 				frame.CloseWindowEventually()
 			} else {
@@ -97,7 +36,7 @@ func TestWindow_Loop(t *testing.T) {
 
 	t.Run("frame should provide Image for the whole window", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		windows := pixiq.NewWindows(images, &systemWindowsMock{})
+		windows := pixiq.NewWindows(images)
 		tests := map[string]struct {
 			width, height int
 		}{
@@ -112,10 +51,10 @@ func TestWindow_Loop(t *testing.T) {
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				window := windows.New(test.width, test.height)
 				var image *pixiq.Image
+				win := &windowMock{width: test.width, height: test.height}
 				// when
-				window.Loop(func(frame *pixiq.Frame) {
+				windows.Loop(win, func(frame *pixiq.Frame) {
 					image = frame.Image()
 					frame.CloseWindowEventually()
 				})
@@ -126,31 +65,14 @@ func TestWindow_Loop(t *testing.T) {
 		}
 	})
 
-	t.Run("should open system window", func(t *testing.T) {
-		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		systemWindows := &systemWindowsMock{}
-		windows := pixiq.NewWindows(images, systemWindows)
-		window := windows.New(1, 2)
-		// when
-		window.Loop(func(frame *pixiq.Frame) {
-			frame.CloseWindowEventually()
-		})
-		// then
-		require.Len(t, systemWindows.openWindows, 1)
-		win := systemWindows.openWindows[0]
-		assert.Equal(t, 1, win.width)
-		assert.Equal(t, 2, win.height)
-	})
-
 	t.Run("should draw image for each frame", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		systemWindows := &systemWindowsMock{}
-		windows := pixiq.NewWindows(images, systemWindows)
-		window := windows.New(0, 0)
+		win := &windowMock{}
+		windows := pixiq.NewWindows(images)
 		firstFrame := true
 		var recordedImages []*pixiq.Image
 		// when
-		window.Loop(func(frame *pixiq.Frame) {
+		windows.Loop(win, func(frame *pixiq.Frame) {
 			if !firstFrame {
 				frame.CloseWindowEventually()
 			}
@@ -158,18 +80,16 @@ func TestWindow_Loop(t *testing.T) {
 			recordedImages = append(recordedImages, frame.Image())
 		})
 		// then
-		require.Len(t, systemWindows.openWindows, 1)
-		win := systemWindows.openWindows[0]
 		assert.Equal(t, recordedImages, win.imagesDrawn)
 	})
 
 	t.Run("initial window image is transparent", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		windows := pixiq.NewWindows(images, &systemWindowsMock{})
-		window := windows.New(1, 1)
+		windows := pixiq.NewWindows(images)
+		win := &windowMock{width: 1, height: 1}
 		var image *pixiq.Image
 		// when
-		window.Loop(func(frame *pixiq.Frame) {
+		windows.Loop(win, func(frame *pixiq.Frame) {
 			image = frame.Image()
 			frame.CloseWindowEventually()
 		})
@@ -181,18 +101,15 @@ func TestWindow_Loop(t *testing.T) {
 		t.Run("after first frame", func(t *testing.T) {
 			color := pixiq.RGBA(10, 20, 30, 40)
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(images, systemWindows)
-			window := windows.New(1, 1)
+			win := &windowMock{width: 1, height: 1}
+			windows := pixiq.NewWindows(images)
 			// when
-			window.Loop(func(frame *pixiq.Frame) {
+			windows.Loop(win, func(frame *pixiq.Frame) {
 				selection := frame.Image().Selection(0, 0)
 				selection.SetColor(0, 0, color)
 				frame.CloseWindowEventually()
 			})
 			// then
-			require.Len(t, systemWindows.openWindows, 1)
-			win := systemWindows.openWindows[0]
 			require.Len(t, win.imagesDrawn, 1)
 			assert.Equal(t, color, win.imagesDrawn[0].WholeImageSelection().Color(0, 0))
 		})
@@ -200,12 +117,11 @@ func TestWindow_Loop(t *testing.T) {
 			color1 := pixiq.RGBA(10, 20, 30, 40)
 			color2 := pixiq.RGBA(10, 20, 30, 40)
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(images, systemWindows)
-			window := windows.New(1, 1)
+			win := &windowMock{width: 1, height: 1}
+			windows := pixiq.NewWindows(images)
 			firstFrame := true
 			// when
-			window.Loop(func(frame *pixiq.Frame) {
+			windows.Loop(win, func(frame *pixiq.Frame) {
 				selection := frame.Image().WholeImageSelection()
 				if firstFrame {
 					selection.SetColor(0, 0, color1)
@@ -216,58 +132,38 @@ func TestWindow_Loop(t *testing.T) {
 				}
 			})
 			// then
-			require.Len(t, systemWindows.openWindows, 1)
-			win := systemWindows.openWindows[0]
 			require.Len(t, win.imagesDrawn, 2)
 			assert.Equal(t, color1, win.imagesDrawn[0].WholeImageSelection().Color(0, 0))
 			assert.Equal(t, color2, win.imagesDrawn[1].WholeImageSelection().Color(0, 0))
 		})
 	})
 
-	t.Run("should open window with given dimensions", func(t *testing.T) {
-		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		systemWindows := &systemWindowsMock{}
-		windows := pixiq.NewWindows(images, systemWindows)
-		window := windows.New(1, 2)
-		// when
-		window.Loop(func(frame *pixiq.Frame) {
-			frame.CloseWindowEventually()
-		})
-		// then
-		assert.Equal(t, 1, systemWindows.openWindows[0].width)
-		assert.Equal(t, 2, systemWindows.openWindows[0].height)
-	})
-
 	t.Run("should swap images", func(t *testing.T) {
 		t.Run("after first frame", func(t *testing.T) {
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(images, systemWindows)
-			window := windows.New(0, 0)
+			openWindow := &windowMock{}
+			windows := pixiq.NewWindows(images)
 			// when
-			window.Loop(func(frame *pixiq.Frame) {
+			windows.Loop(openWindow, func(frame *pixiq.Frame) {
 				frame.CloseWindowEventually()
 			})
 			// then
-			openWindow := systemWindows.openWindows[0]
 			require.Len(t, openWindow.imagesDrawn, 1)
 			assert.Same(t, openWindow.imagesDrawn[0], openWindow.visibleImage)
 		})
 		t.Run("after second frame", func(t *testing.T) {
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
-			systemWindows := &systemWindowsMock{}
-			windows := pixiq.NewWindows(images, systemWindows)
-			window := windows.New(0, 0)
+			openWindow := &windowMock{}
+			windows := pixiq.NewWindows(images)
 			firstFrame := true
 			// when
-			window.Loop(func(frame *pixiq.Frame) {
+			windows.Loop(openWindow, func(frame *pixiq.Frame) {
 				if !firstFrame {
 					frame.CloseWindowEventually()
 				}
 				firstFrame = false
 			})
 			// then
-			openWindow := systemWindows.openWindows[0]
 			require.Len(t, openWindow.imagesDrawn, 2)
 			assert.Same(t, openWindow.imagesDrawn[1], openWindow.visibleImage)
 		})
@@ -275,57 +171,51 @@ func TestWindow_Loop(t *testing.T) {
 
 	t.Run("should close the window after loop is finished", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		systemWindows := &systemWindowsMock{}
-		windows := pixiq.NewWindows(images, systemWindows)
-		window := windows.New(0, 0)
+		win := &windowMock{}
+		windows := pixiq.NewWindows(images)
 		frameNumber := 0
 		// when
-		window.Loop(func(frame *pixiq.Frame) {
+		windows.Loop(win, func(frame *pixiq.Frame) {
 			if frameNumber == 2 {
 				frame.CloseWindowEventually()
 			} else {
 				// then
-				require.Len(t, systemWindows.openWindows, 1)
-				assert.False(t, systemWindows.openWindows[0].closed)
+				assert.False(t, win.closed)
 				frameNumber += 1
 			}
 		})
 		// then
-		require.Len(t, systemWindows.openWindows, 1)
-		assert.True(t, systemWindows.openWindows[0].closed)
+		assert.True(t, win.closed)
 	})
 
 }
 
-type systemWindowsMock struct {
-	openWindows []*systemWindowMock
-}
-
-func (s *systemWindowsMock) Open(width, height int, hints ...pixiq.WindowHint) pixiq.SystemWindow {
-	win := &systemWindowMock{width: width, height: height, hints: hints}
-	s.openWindows = append(s.openWindows, win)
-	return win
-}
-
-type systemWindowMock struct {
+type windowMock struct {
 	imagesDrawn  []*pixiq.Image
 	width        int
 	height       int
 	visibleImage *pixiq.Image
 	closed       bool
-	hints        []pixiq.WindowHint
 }
 
-func (f *systemWindowMock) Draw(image *pixiq.Image) {
+func (f *windowMock) Draw(image *pixiq.Image) {
 	f.imagesDrawn = append(f.imagesDrawn, clone(image))
 }
 
-func (f *systemWindowMock) SwapImages() {
+func (f *windowMock) SwapImages() {
 	f.visibleImage = f.imagesDrawn[len(f.imagesDrawn)-1]
 }
 
-func (f *systemWindowMock) Close() {
+func (f *windowMock) Close() {
 	f.closed = true
+}
+
+func (f *windowMock) Width() int {
+	return f.width
+}
+
+func (f *windowMock) Height() int {
+	return f.height
 }
 
 func clone(original *pixiq.Image) *pixiq.Image {


### PR DESCRIPTION
After some brainstorming we realized that Windows API is not helpful at all. Different devices have different properties and is really hard to create an abstraction for creating windows on every possible device.