### PR TITLE
Rename Screens to ScreenLoops

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,13 @@ import (
 var white = pixiq.RGBA(255, 255, 255, 255)
 
 func main() {
-	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 		window := gl.Windows().Open(320, 16)
-		screens.Loop(window, func(frame *pixiq.Frame) {
+		loops.Loop(window, func(frame *pixiq.Frame) {
 			frame.Screen().SetColor(160, 8, white)
 		})
 	})
 }
-
 ```
 
 ## Project status

--- a/cmd/examples/hello-world/main.go
+++ b/cmd/examples/hello-world/main.go
@@ -9,12 +9,12 @@ var white = pixiq.RGBA(255, 255, 255, 255)
 
 func main() {
 	// Use OpenGL on PCs with Linux, Windows and MacOS. This package can open windows and draw images on them.
-	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 		window := gl.Windows().Open(320, 16)
 		// Create a main loop for a screen. OpenGL's Window is a Screen (some day in the future Pixiq may support
 		// different platforms such as mobile or browser, therefore we need a Screen abstraction).
 		// Each iteration of the loop is a Frame.
-		screens.Loop(window, func(frame *pixiq.Frame) {
+		loops.Loop(window, func(frame *pixiq.Frame) {
 			frame.Screen().SetColor(160, 8, white)
 		})
 	})

--- a/cmd/examples/windows/closing/main.go
+++ b/cmd/examples/windows/closing/main.go
@@ -6,9 +6,9 @@ import (
 )
 
 func main() {
-	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 		window := gl.Windows().Open(320, 180)
-		screens.Loop(window, func(frame *pixiq.Frame) {
+		loops.Loop(window, func(frame *pixiq.Frame) {
 			if window.ShouldClose() {
 				frame.StopLoopEventually()
 			}

--- a/cmd/examples/windows/multiple/main.go
+++ b/cmd/examples/windows/multiple/main.go
@@ -11,12 +11,12 @@ var (
 )
 
 func main() {
-	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+	opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 		windows := gl.Windows()
 		redWindow := windows.Open(320, 180)
 		blueWindow := windows.Open(250, 90)
-		go screens.Loop(redWindow, fillWith(red))
-		screens.Loop(blueWindow, fillWith(blue))
+		go loops.Loop(redWindow, fillWith(red))
+		loops.Loop(blueWindow, fillWith(blue))
 	})
 }
 

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -31,12 +31,12 @@ func New(loop *MainThreadLoop) *OpenGL {
 
 // Run is a shorthand method for creating pixiq objects with OpenGL acceleration and windows. It runs the given callback
 // function and blocks. It was created mainly for educational purposes to save a few keystrokes.
-func Run(main func(gl *OpenGL, images *pixiq.Images, screens *pixiq.Screens)) {
+func Run(main func(gl *OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops)) {
 	StartMainThreadLoop(func(loop *MainThreadLoop) {
 		openGL := New(loop)
 		images := pixiq.NewImages(openGL.AcceleratedImages())
-		screens := pixiq.NewScreens(images)
-		main(openGL, images, screens)
+		loops := pixiq.NewScreenLoops(images)
+		main(openGL, images, loops)
 	})
 }
 

--- a/opengl/opengl_test.go
+++ b/opengl/opengl_test.go
@@ -224,7 +224,7 @@ func TestRun(t *testing.T) {
 	t.Run("should run provided callback", func(t *testing.T) {
 		var callbackExecuted bool
 		mainThreadLoop.Execute(func() {
-			opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+			opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 				callbackExecuted = true
 			})
 		})
@@ -232,22 +232,22 @@ func TestRun(t *testing.T) {
 	})
 	t.Run("should create pixiq objects using OpenGL acceleration and windows", func(t *testing.T) {
 		var (
-			actualGL      *opengl.OpenGL
-			actualImages  *pixiq.Images
-			actualScreens *pixiq.Screens
+			actualGL     *opengl.OpenGL
+			actualImages *pixiq.Images
+			actualLoops  *pixiq.ScreenLoops
 		)
 		mainThreadLoop.Execute(func() {
-			opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, screens *pixiq.Screens) {
+			opengl.Run(func(gl *opengl.OpenGL, images *pixiq.Images, loops *pixiq.ScreenLoops) {
 				actualGL = gl
 				actualImages = images
-				actualScreens = screens
+				actualLoops = loops
 			})
 		})
 		assert.NotNil(t, actualGL)
 		assert.NotNil(t, actualGL.Windows())
 		assert.NotNil(t, actualGL.AcceleratedImages())
 		assert.NotNil(t, actualImages)
-		assert.NotNil(t, actualScreens)
+		assert.NotNil(t, actualLoops)
 	})
 
 }

--- a/screen_loops.go
+++ b/screen_loops.go
@@ -1,12 +1,12 @@
 package pixiq
 
-// NewScreens returns a new instance of Screens
-func NewScreens(images *Images) *Screens {
-	return &Screens{images: images}
+// NewScreenLoops returns a new instance of ScreenLoops
+func NewScreenLoops(images *Images) *ScreenLoops {
+	return &ScreenLoops{images: images}
 }
 
-// Screens is an abstraction for interaction with screens in a platform-agnostic way
-type Screens struct {
+// ScreenLoops is an abstraction for interaction with screens in a platform-agnostic way
+type ScreenLoops struct {
 	images *Images
 }
 
@@ -24,7 +24,7 @@ type Screen interface {
 
 // Loop starts the main loop. It will execute onEachFrame function for each frame, as soon as loop is stopped. This
 // function blocks the current goroutine.
-func (w *Screens) Loop(screen Screen, onEachFrame func(frame *Frame)) {
+func (w *ScreenLoops) Loop(screen Screen, onEachFrame func(frame *Frame)) {
 	frame := &Frame{}
 	image := w.images.New(screen.Width(), screen.Height())
 	frame.screen = image.WholeImageSelection()

--- a/screen_loops_bench_test.go
+++ b/screen_loops_bench_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/jacekolszak/pixiq"
 )
 
-func BenchmarkScreens_Loop(b *testing.B) {
+func BenchmarkScreenLoops_Loop(b *testing.B) {
 	b.StopTimer()
 	images := pixiq.NewImages(&fakeAcceleratedImages{})
-	screens := pixiq.NewScreens(images)
+	screenLoops := pixiq.NewScreenLoops(images)
 	screen := &noopScreen{}
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		frameNumber := 0
-		screens.Loop(screen, func(frame *pixiq.Frame) {
+		screenLoops.Loop(screen, func(frame *pixiq.Frame) {
 			frameNumber++
 			if frameNumber > 10000 {
 				frame.StopLoopEventually()

--- a/screen_loops_test.go
+++ b/screen_loops_test.go
@@ -9,21 +9,21 @@ import (
 	"github.com/jacekolszak/pixiq"
 )
 
-func TestNewScreens(t *testing.T) {
-	t.Run("should return Screens object", func(t *testing.T) {
-		screens := pixiq.NewScreens(pixiq.NewImages(&fakeAcceleratedImages{}))
-		assert.NotNil(t, screens)
+func TestNewScreenLoops(t *testing.T) {
+	t.Run("should return ScreenLoops object", func(t *testing.T) {
+		loops := pixiq.NewScreenLoops(pixiq.NewImages(&fakeAcceleratedImages{}))
+		assert.NotNil(t, loops)
 	})
 }
 
-func TestScreens_Loop(t *testing.T) {
+func TestScreenLoops_Loop(t *testing.T) {
 
 	t.Run("should run callback function until loop is stopped", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		screens := pixiq.NewScreens(images)
+		loops := pixiq.NewScreenLoops(images)
 		frameNumber := 0
 		// when
-		screens.Loop(&screenMock{}, func(frame *pixiq.Frame) {
+		loops.Loop(&screenMock{}, func(frame *pixiq.Frame) {
 			if frameNumber == 2 {
 				frame.StopLoopEventually()
 			} else {
@@ -36,7 +36,7 @@ func TestScreens_Loop(t *testing.T) {
 
 	t.Run("frame should provide screen", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		screens := pixiq.NewScreens(images)
+		loops := pixiq.NewScreenLoops(images)
 		tests := map[string]struct {
 			width, height int
 		}{
@@ -53,7 +53,7 @@ func TestScreens_Loop(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				var screen pixiq.Selection
 				// when
-				screens.Loop(&screenMock{width: test.width, height: test.height}, func(frame *pixiq.Frame) {
+				loops.Loop(&screenMock{width: test.width, height: test.height}, func(frame *pixiq.Frame) {
 					screen = frame.Screen()
 					frame.StopLoopEventually()
 				})
@@ -72,11 +72,11 @@ func TestScreens_Loop(t *testing.T) {
 	t.Run("should draw image for each frame", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
 		screen := &screenMock{}
-		screens := pixiq.NewScreens(images)
+		loops := pixiq.NewScreenLoops(images)
 		firstFrame := true
 		var recordedImages []*pixiq.Image
 		// when
-		screens.Loop(screen, func(frame *pixiq.Frame) {
+		loops.Loop(screen, func(frame *pixiq.Frame) {
 			if !firstFrame {
 				frame.StopLoopEventually()
 			}
@@ -89,10 +89,10 @@ func TestScreens_Loop(t *testing.T) {
 
 	t.Run("initial screen is transparent", func(t *testing.T) {
 		images := pixiq.NewImages(&fakeAcceleratedImages{})
-		screens := pixiq.NewScreens(images)
+		loops := pixiq.NewScreenLoops(images)
 		var screen pixiq.Selection
 		// when
-		screens.Loop(&screenMock{width: 1, height: 1}, func(frame *pixiq.Frame) {
+		loops.Loop(&screenMock{width: 1, height: 1}, func(frame *pixiq.Frame) {
 			screen = frame.Screen()
 			frame.StopLoopEventually()
 		})
@@ -105,9 +105,9 @@ func TestScreens_Loop(t *testing.T) {
 			color := pixiq.RGBA(10, 20, 30, 40)
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
 			screen := &screenMock{width: 1, height: 1}
-			screens := pixiq.NewScreens(images)
+			loops := pixiq.NewScreenLoops(images)
 			// when
-			screens.Loop(screen, func(frame *pixiq.Frame) {
+			loops.Loop(screen, func(frame *pixiq.Frame) {
 				frame.Screen().SetColor(0, 0, color)
 				frame.StopLoopEventually()
 			})
@@ -120,10 +120,10 @@ func TestScreens_Loop(t *testing.T) {
 			color2 := pixiq.RGBA(10, 20, 30, 40)
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
 			screen := &screenMock{width: 1, height: 1}
-			screens := pixiq.NewScreens(images)
+			loops := pixiq.NewScreenLoops(images)
 			firstFrame := true
 			// when
-			screens.Loop(screen, func(frame *pixiq.Frame) {
+			loops.Loop(screen, func(frame *pixiq.Frame) {
 				if firstFrame {
 					frame.Screen().SetColor(0, 0, color1)
 					firstFrame = false
@@ -143,9 +143,9 @@ func TestScreens_Loop(t *testing.T) {
 		t.Run("after first frame", func(t *testing.T) {
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
 			screen := &screenMock{}
-			screens := pixiq.NewScreens(images)
+			loops := pixiq.NewScreenLoops(images)
 			// when
-			screens.Loop(screen, func(frame *pixiq.Frame) {
+			loops.Loop(screen, func(frame *pixiq.Frame) {
 				frame.StopLoopEventually()
 			})
 			// then
@@ -155,10 +155,10 @@ func TestScreens_Loop(t *testing.T) {
 		t.Run("after second frame", func(t *testing.T) {
 			images := pixiq.NewImages(&fakeAcceleratedImages{})
 			screen := &screenMock{}
-			screens := pixiq.NewScreens(images)
+			loops := pixiq.NewScreenLoops(images)
 			firstFrame := true
 			// when
-			screens.Loop(screen, func(frame *pixiq.Frame) {
+			loops.Loop(screen, func(frame *pixiq.Frame) {
 				if !firstFrame {
 					frame.StopLoopEventually()
 				}


### PR DESCRIPTION
Screens name is too broad. It is used only for looping screens, so I decided to change the name to more meaningful one.