### PR TITLE
Optimize image download

### DIFF
--- a/gl/gl.go
+++ b/gl/gl.go
@@ -7,8 +7,6 @@
 package gl
 
 import (
-	"unsafe"
-
 	"github.com/jacekolszak/pixiq/image"
 )
 
@@ -200,18 +198,11 @@ func (a *VertexArray) Set(location int, pointer VertexBufferPointer) {
 		typ.xtype,
 		false,
 		int32(pointer.Stride*4),
-		PtrOffset(pointer.Offset*4),
+		a.api.PtrOffset(pointer.Offset*4),
 	)
 }
 
 // ID returns VertexArray identifier (aka name)
 func (a *VertexArray) ID() uint32 {
 	return a.id
-}
-
-// PtrOffset takes a pointer offset and returns a GL-compatible pointer.
-// Useful for functions such as glVertexAttribPointer that take pointer
-// parameters indicating an offset rather than an absolute memory address.
-func PtrOffset(offset int) unsafe.Pointer {
-	return unsafe.Pointer(uintptr(offset))
 }

--- a/gl/integration/opengl/opengl_bench_test.go
+++ b/gl/integration/opengl/opengl_bench_test.go
@@ -18,6 +18,7 @@ func BenchmarkAcceleratedImage_Upload(b *testing.B) {
 	}
 	img := openGL.Context().NewAcceleratedImage(1, 1)
 	pixels := []image.Color{image.Transparent, image.Transparent}
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img.Upload(pixels)

--- a/image/image.go
+++ b/image/image.go
@@ -251,6 +251,7 @@ func (s Selection) Modify(command AcceleratedCommand, selections ...Selection) {
 	}
 	convertedSelections := s.image.selectionsCache[:0]
 	for _, selection := range selections {
+		// TODO This will fail
 		selection.image.acceleratedImage.Upload(selection.image.pixels)
 		convertedSelections = append(convertedSelections, selection.toAcceleratedImageSelection())
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -94,7 +94,9 @@ func (i *Image) WholeImageSelection() Selection {
 //
 // DEPRECATED - this method will be removed in next release
 func (i *Image) Upload() {
-	i.acceleratedImage.Upload(i.pixels)
+	if !i.acceleratedImageModified {
+		i.acceleratedImage.Upload(i.pixels)
+	}
 }
 
 // Selection points to a specific area of the image. It has a starting position
@@ -251,8 +253,7 @@ func (s Selection) Modify(command AcceleratedCommand, selections ...Selection) {
 	}
 	convertedSelections := s.image.selectionsCache[:0]
 	for _, selection := range selections {
-		// TODO This will fail
-		selection.image.acceleratedImage.Upload(selection.image.pixels)
+		selection.image.Upload()
 		convertedSelections = append(convertedSelections, selection.toAcceleratedImageSelection())
 	}
 	command.Run(s.toAcceleratedImageSelection(), convertedSelections)

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -14,6 +14,7 @@ func BenchmarkSelection_SetColor(b *testing.B) {
 		height    = selection.Height()
 		width     = selection.Width()
 	)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
@@ -31,6 +32,7 @@ func BenchmarkSelection_Color(b *testing.B) {
 		height    = selection.Height()
 		width     = selection.Width()
 	)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -441,19 +441,21 @@ func TestSelection_SetColor(t *testing.T) {
 		var (
 			color        = image.RGBA(10, 20, 30, 40)
 			commandColor = image.RGBA(50, 60, 70, 80)
-			accImg       = fake.NewAcceleratedImage(1, 1)
-			img          = image.New(1, 1, accImg)
+			accImg       = fake.NewAcceleratedImage(2, 1)
+			img          = image.New(2, 1, accImg)
 			selection    = img.Selection(0, 0)
 		)
 		selection.Modify(&acceleratedCommandMock{
 			command: func(image.AcceleratedImageSelection, []image.AcceleratedImageSelection) {
-				accImg.Upload([]image.Color{commandColor})
+				accImg.Upload([]image.Color{commandColor, commandColor})
 			},
 		})
 		// when
 		selection.SetColor(0, 0, color)
 		// then
 		assert.Equal(t, color, selection.Color(0, 0))
+		// and
+		assert.Equal(t, commandColor, selection.Color(1, 0))
 	})
 
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -436,6 +436,26 @@ func TestSelection_SetColor(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("SetColor overrides color set by AcceleratedCommand", func(t *testing.T) {
+		var (
+			color        = image.RGBA(10, 20, 30, 40)
+			commandColor = image.RGBA(50, 60, 70, 80)
+			accImg       = fake.NewAcceleratedImage(1, 1)
+			img          = image.New(1, 1, accImg)
+			selection    = img.Selection(0, 0)
+		)
+		selection.Modify(&acceleratedCommandMock{
+			command: func(image.AcceleratedImageSelection, []image.AcceleratedImageSelection) {
+				accImg.Upload([]image.Color{commandColor})
+			},
+		})
+		// when
+		selection.SetColor(0, 0, color)
+		// then
+		assert.Equal(t, color, selection.Color(0, 0))
+	})
+
 }
 
 func TestImage_Upload(t *testing.T) {
@@ -744,6 +764,7 @@ func TestSelection_Modify(t *testing.T) {
 		assert.Equal(t, color01, outputSelection.Color(0, 1))
 		assert.Equal(t, color11, outputSelection.Color(1, 1))
 	})
+
 }
 
 func assertColors(t *testing.T, selection image.Selection, expectedColorLines [][]image.Color) {

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -12,7 +12,7 @@ func New() *Tool {
 // Tool is a clearing tool. It clears the image.Selection with specific color
 // which basically means setting the color for each pixel in the selection.
 //
-// Tool is using CPU.
+// Tool uses CPU.
 type Tool struct {
 	color image.Color
 }

--- a/tools/glclear/glclear.go
+++ b/tools/glclear/glclear.go
@@ -18,7 +18,7 @@ func New(command *gl.ClearCommand) *Tool {
 // Tool is a clearing tool. It clears the image.Selection with specific color
 // which basically means setting the color for each pixel in the selection.
 //
-// Tool is using GPU through use of *gl.ClearCommand
+// Tool uses GPU through use of *gl.ClearCommand
 type Tool struct {
 	command *gl.ClearCommand
 }


### PR DESCRIPTION
Image should be downloaded only when really needed. For instance when image has been modified on GPU it does not have to be downloaded unless we want to read it's color. 