### PR TITLE
add selection lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pixiq
 
 [![CircleCI](https://circleci.com/gh/jacekolszak/pixiq.svg?style=svg)](https://circleci.com/gh/jacekolszak/pixiq)
-[![GoDoc](https://godoc.org/github.com/jacekolszak/pixiq?status.svg)](http://godoc.org/github.com/jacekolszak/pixiq)
+[![GoDoc](https://godoc.org/github.com/jacekolszak/pixiq?status.svg)](https://pkg.go.dev/mod/github.com/jacekolszak/pixiq)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jacekolszak/pixiq)](https://goreportcard.com/report/github.com/jacekolszak/pixiq)
 
 Create Pixel Art games in Golang with fun and ease.

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,0 @@
-package pixiq

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,1 @@
+package pixiq

--- a/examples/image/lines/main.go
+++ b/examples/image/lines/main.go
@@ -18,9 +18,9 @@ func main() {
 		loop.Run(window, func(frame *loop.Frame) {
 			screen := frame.Screen()
 			for y := 0; y < screen.Height(); y++ {
-				line := screen.Line(y)
-				for x := 0; x < line.Width(); x++ {
-					line.SetColor(x, colornames.Blue)
+				line := screen.LineForWrite(y)
+				for x := 0; x < len(line); x++ {
+					line[x] = colornames.Blue
 				}
 			}
 		})

--- a/examples/image/lines/main.go
+++ b/examples/image/lines/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+
+	"github.com/jacekolszak/pixiq/colornames"
+	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/jacekolszak/pixiq/loop"
+)
+
+// This example show how to efficiently set all pixels using Lines
+func main() {
+	glfw.RunOrDie(func(gl *glfw.OpenGL) {
+		window, err := gl.OpenWindow(640, 360)
+		if err != nil {
+			log.Panicf("OpenWindow failed: %v", err)
+		}
+		loop.Run(window, func(frame *loop.Frame) {
+			screen := frame.Screen()
+			for y := 0; y < screen.Height(); y++ {
+				line := screen.Line(y)
+				for x := 0; x < line.Width(); x++ {
+					line.SetColor(x, colornames.Blue)
+				}
+			}
+		})
+	})
+}

--- a/examples/image/lines/main.go
+++ b/examples/image/lines/main.go
@@ -17,8 +17,9 @@ func main() {
 		}
 		loop.Run(window, func(frame *loop.Frame) {
 			screen := frame.Screen()
-			for y := 0; y < screen.Height(); y++ {
-				line := screen.LineForWrite(y)
+			lines := screen.Lines()
+			for y := 0; y < lines.Length(); y++ {
+				line := lines.LineForWrite(y)
 				for x := 0; x < len(line); x++ {
 					line[x] = colornames.Blue
 				}

--- a/examples/image/lines/main.go
+++ b/examples/image/lines/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
 	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/jacekolszak/pixiq/image"
 	"github.com/jacekolszak/pixiq/loop"
 )
 
-// This example show how to efficiently set all pixels using Lines
+// This example shows how to set all pixels using Lines
 func main() {
 	glfw.RunOrDie(func(gl *glfw.OpenGL) {
 		window, err := gl.OpenWindow(640, 360)
@@ -21,7 +21,8 @@ func main() {
 			for y := 0; y < lines.Length(); y++ {
 				line := lines.LineForWrite(y)
 				for x := 0; x < len(line); x++ {
-					line[x] = colornames.Blue
+					color := image.RGBA(byte(x%255), byte(y%255), 255, 255)
+					line[x] = color
 				}
 			}
 		})

--- a/image/doc.go
+++ b/image/doc.go
@@ -1,4 +1,4 @@
-// Package image provides hardware-supported Image primitive which can be
+// Package image provides hardware-accelerated Image primitive which can be
 // manipulated in real-time using Pixel-Perfect API.
 //
 // Instance of the Image should be created either by directly using a New function

--- a/image/image.go
+++ b/image/image.go
@@ -283,18 +283,20 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 // instead.
 //
 // Please note that return slice behaves differently than Selection. Line contains only
-// real pixels and trying to access out-of-bounds pixels generates panic.
+// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
+// the len of returned slice might be lower than Selection. The starting offset is
+// returned as a second return value.
 //
 // It is not safe to retain Line for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
-func (s Selection) LineForRead(y int) []Color {
+func (s Selection) LineForRead(y int) (slice []Color, offset int) {
 	if s.image.acceleratedImageModified {
 		s.image.acceleratedImage.Download(s.image.pixels)
 		s.image.acceleratedImageModified = false
 	}
 	start := (s.y+y)*s.image.width + s.x
 	stop := start + s.width
-	return s.image.pixels[start:stop]
+	return s.image.pixels[start:stop], 0
 }
 
 // LineForWrite returns Selection pixels in a given line which can be used for
@@ -303,11 +305,13 @@ func (s Selection) LineForRead(y int) []Color {
 // You may read and write to returned slice.
 //
 // Please note that return slice behaves differently than Selection. Line contains only
-// real pixels and trying to access out-of-bounds pixels generates panic.
+// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
+// the len of returned slice might be lower than Selection. The starting offset is
+// returned as a second return value.
 //
 // It is not safe to retain Line for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
-func (s Selection) LineForWrite(y int) []Color {
+func (s Selection) LineForWrite(y int) (slice []Color, offset int) {
 	if s.image.acceleratedImageModified {
 		s.image.acceleratedImage.Download(s.image.pixels)
 		s.image.acceleratedImageModified = false
@@ -315,5 +319,5 @@ func (s Selection) LineForWrite(y int) []Color {
 	s.image.ramModified = true
 	start := (s.y+y)*s.image.width + s.x
 	stop := start + s.width
-	return s.image.pixels[start:stop]
+	return s.image.pixels[start:stop], 0
 }

--- a/image/image.go
+++ b/image/image.go
@@ -353,6 +353,7 @@ func (l Lines) YOffset() int {
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForWrite(line int) []Color {
 	// TODO Should download AcceleratedImage if it was modified first
+
 	pixels := l.line(line)
 	l.image.ramModified = true
 	return pixels

--- a/image/image.go
+++ b/image/image.go
@@ -337,12 +337,12 @@ func (l Lines) LineForWrite(line int) []Color {
 	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.xOffset
-	stop := start + l.image.width - l.xOffset
+	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.startX
+	stop := start + l.image.width
 	if start < 0 {
 		start = 0
 	}
-	if stop < start {
+	if stop > len(l.image.pixels) {
 		return []Color{}
 	}
 	return l.image.pixels[start:stop]
@@ -358,12 +358,12 @@ func (l Lines) LineForRead(line int) []Color {
 	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.xOffset
-	stop := start + l.image.width - l.xOffset
+	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.startX
+	stop := start + l.image.width
 	if start < 0 {
 		start = 0
 	}
-	if stop < start {
+	if stop > len(l.image.pixels) {
 		return []Color{}
 	}
 	return l.image.pixels[start:stop]

--- a/image/image.go
+++ b/image/image.go
@@ -288,41 +288,53 @@ func (s Selection) Line(y int) Line {
 	if start >= len(s.image.pixels) {
 		start = len(s.image.pixels) - 1
 	}
-	if stop >= len(s.image.pixels) {
-		stop = len(s.image.pixels) - 1
+	if stop > len(s.image.pixels) {
+		stop = len(s.image.pixels)
 	}
 	return Line{
-		pixels: s.image.pixels[start:stop],
-		x:      s.x}
+		line:      s.image.pixels[start:stop],
+		imageLine: s.image.pixels[start:stop],
+		x:         s.x,
+		width:     s.width,
+	}
 }
 
 type Line struct {
-	x      int
-	pixels []Color
+	x         int
+	width     int
+	line      []Color
+	imageLine []Color
 }
 
 func (l Line) Width() int {
-	return len(l.pixels)
+	return l.width
 }
 
 func (l Line) SetColor(x int, color Color) {
-	x = l.x + x
-	if x < 0 {
+	if x >= 0 && x < len(l.line) {
+		l.line[x] = color
 		return
 	}
-	if x >= len(l.pixels) {
+	imageX := l.x + x
+	if imageX < 0 {
 		return
 	}
-	l.pixels[x] = color
+	if imageX >= len(l.imageLine) {
+		return
+	}
+	l.imageLine[x] = color
 }
 
 func (l Line) Color(x int) Color {
-	x = l.x + x
-	if x < 0 {
+	if x >= 0 && x < len(l.line) {
+		return l.line[x]
+	}
+	imageX := l.x + x
+	if imageX < 0 {
 		return Transparent
 	}
-	if x >= len(l.pixels) {
+	if imageX >= len(l.imageLine) {
 		return Transparent
 	}
-	return l.pixels[x]
+	return l.imageLine[x]
 }

--- a/image/image.go
+++ b/image/image.go
@@ -282,7 +282,7 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 // when Modify is run. If you want to update the line contents please use LineForWrite
 // instead.
 //
-// Please note that return slice behaves differently than Selection. Line contains only
+// Please note that returned slice behaves differently than Selection. Line contains only
 // real pixels and trying to access out-of-bounds pixels generates panic. Therefore
 // the len of returned slice might be lower than Selection. The starting offset is
 // returned as a second return value.
@@ -290,13 +290,21 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 // It is not safe to retain Line for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (s Selection) LineForRead(y int) (slice []Color, offset int) {
-	if s.image.acceleratedImageModified {
-		s.image.acceleratedImage.Download(s.image.pixels)
-		s.image.acceleratedImageModified = false
+	imageY := y + s.y
+	if imageY < 0 {
+		panic("line out-of-bounds the image")
 	}
-	start := (s.y+y)*s.image.width + s.x
-	stop := start + s.width
-	return s.image.pixels[start:stop], 0
+	if imageY >= s.image.height {
+		panic("line out-of-bounds the image")
+	}
+	//if s.image.acceleratedImageModified {
+	//	s.image.acceleratedImage.Download(s.image.pixels)
+	//	s.image.acceleratedImageModified = false
+	//}
+	//start := (s.y+y)*s.image.width + s.x
+	//stop := start + s.width
+	//return s.image.pixels[start:stop], 0
+	return nil, 0
 }
 
 // LineForWrite returns Selection pixels in a given line which can be used for
@@ -304,7 +312,7 @@ func (s Selection) LineForRead(y int) (slice []Color, offset int) {
 //
 // You may read and write to returned slice.
 //
-// Please note that return slice behaves differently than Selection. Line contains only
+// Please note that returned slice behaves differently than Selection. Line contains only
 // real pixels and trying to access out-of-bounds pixels generates panic. Therefore
 // the len of returned slice might be lower than Selection. The starting offset is
 // returned as a second return value.
@@ -312,12 +320,13 @@ func (s Selection) LineForRead(y int) (slice []Color, offset int) {
 // It is not safe to retain Line for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (s Selection) LineForWrite(y int) (slice []Color, offset int) {
-	if s.image.acceleratedImageModified {
-		s.image.acceleratedImage.Download(s.image.pixels)
-		s.image.acceleratedImageModified = false
-	}
-	s.image.ramModified = true
-	start := (s.y+y)*s.image.width + s.x
-	stop := start + s.width
-	return s.image.pixels[start:stop], 0
+	//if s.image.acceleratedImageModified {
+	//	s.image.acceleratedImage.Download(s.image.pixels)
+	//	s.image.acceleratedImageModified = false
+	//}
+	//s.image.ramModified = true
+	//start := (s.y+y)*s.image.width + s.x
+	//stop := start + s.width
+	//return s.image.pixels[start:stop], 0
+	return nil, 0
 }

--- a/image/image.go
+++ b/image/image.go
@@ -184,7 +184,7 @@ func (s Selection) Color(localX, localY int) Color {
 		return Transparent
 	}
 	index := x + y*s.image.width
-	if len(s.image.pixels) <= index {
+	if index >= len(s.image.pixels) {
 		return Transparent
 	}
 	return s.image.pixels[index]
@@ -212,7 +212,7 @@ func (s Selection) SetColor(localX, localY int, color Color) {
 		return
 	}
 	index := x + y*s.image.width
-	if len(s.image.pixels) <= index {
+	if index >= len(s.image.pixels) {
 		return
 	}
 	s.image.pixels[index] = color

--- a/image/image.go
+++ b/image/image.go
@@ -274,6 +274,7 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 	}
 }
 
+// Lines returns Selection pixels as line slices.
 func (s Selection) Lines() Lines {
 	startLine := s.y
 	if startLine < 0 {
@@ -303,35 +304,51 @@ func (s Selection) Lines() Lines {
 		startY:  s.y,
 		startX:  s.x,
 		length:  length,
-		image:   s.image,
 		xOffset: xOffset,
 		yOffset: yOffset,
 		width:   width,
+		image:   s.image,
 	}
 }
 
+// Lines represents lines of pixels created from Selection.
 type Lines struct {
 	startY  int
 	startX  int
-	width   int
 	length  int
 	xOffset int
 	yOffset int
+	width   int
 	image   *Image
 }
 
+// Length return the number of lines
 func (l Lines) Length() int {
 	return l.length
 }
 
+// XOffset returns the offset to the Selection X.
 func (l Lines) XOffset() int {
 	return l.xOffset
 }
 
+// YOffset returns the offset to the Selection Y
 func (l Lines) YOffset() int {
 	return l.yOffset
 }
 
+// LineForWrite returns pixels in a given line which can be used for
+// efficient pixel processing. It was created solely for performance reasons.
+//
+// You may read and write to returned slice.
+//
+// Please note that returned slice behaves differently than Selection. Line contains only
+// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
+// the len of returned slice might be lower than Selection width. The starting offset
+// can be read by executing Lines.XOffset().
+//
+// It is not safe to retain Line for future use. The image might be modified by
+// AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForWrite(line int) []Color {
 	if l.Length() == 0 {
 		panic("zero lines length")
@@ -353,6 +370,21 @@ func (l Lines) LineForWrite(line int) []Color {
 	return l.image.pixels[start:stop]
 }
 
+// LineForRead returns pixels in a given line which can be used for
+// efficient pixel processing. It was created solely for performance reasons.
+//
+// You may only read from returned slice. Trying to update the returned slice will
+// not generate panic, but modified pixels will not be uploaded to AcceleratedImage
+// when Modify is run. If you want to update the line contents please use LineForWrite
+// instead.
+//
+// Please note that returned slice behaves differently than Selection. Line contains only
+// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
+// the len of returned slice might be lower than Selection width. The starting offset
+// can be read by executing Lines.XOffset().
+//
+// It is not safe to retain Line for future use. The image might be modified by
+// AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForRead(line int) []Color {
 	if l.Length() == 0 {
 		panic("zero lines length")
@@ -372,63 +404,4 @@ func (l Lines) LineForRead(line int) []Color {
 		return []Color{}
 	}
 	return l.image.pixels[start:stop]
-}
-
-// LineForRead returns Selection pixels in a given line which can be used for
-// efficient pixel processing. It was created solely for performance reasons.
-//
-// You may only read from returned slice. Trying to update the returned slice will
-// not generate panic, but modified pixels will not be uploaded to AcceleratedImage
-// when Modify is run. If you want to update the line contents please use LineForWrite
-// instead.
-//
-// Please note that returned slice behaves differently than Selection. Line contains only
-// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
-// the len of returned slice might be lower than Selection. The starting offset is
-// returned as a second return value.
-//
-// It is not safe to retain Line for future use. The image might be modified by
-// AcceleratedCommand and changes will not be reflected in a slice.
-func (s Selection) LineForRead(y int) (slice []Color, offset int) {
-	imageY := y + s.y
-	if imageY < 0 {
-		panic("line out-of-bounds the image")
-	}
-	if imageY >= s.image.height {
-		panic("line out-of-bounds the image")
-	}
-	//if s.image.acceleratedImageModified {
-	//	s.image.acceleratedImage.Download(s.image.pixels)
-	//	s.image.acceleratedImageModified = false
-	//}
-	start := 0
-	//start := (s.y+y)*s.image.width + s.x
-	stop := s.image.width
-	//stop := start + s.width
-	//return s.image.pixels[start:stop], 0
-	return s.image.pixels[start:stop], 0
-}
-
-// LineForWrite returns Selection pixels in a given line which can be used for
-// efficient pixel processing. It was created solely for performance reasons.
-//
-// You may read and write to returned slice.
-//
-// Please note that returned slice behaves differently than Selection. Line contains only
-// real pixels and trying to access out-of-bounds pixels generates panic. Therefore
-// the len of returned slice might be lower than Selection. The starting offset is
-// returned as a second return value.
-//
-// It is not safe to retain Line for future use. The image might be modified by
-// AcceleratedCommand and changes will not be reflected in a slice.
-func (s Selection) LineForWrite(y int) (slice []Color, offset int) {
-	//if s.image.acceleratedImageModified {
-	//	s.image.acceleratedImage.Download(s.image.pixels)
-	//	s.image.acceleratedImageModified = false
-	//}
-	//s.image.ramModified = true
-	//start := (s.y+y)*s.image.width + s.x
-	//stop := start + s.width
-	//return s.image.pixels[start:stop], 0
-	return nil, 0
 }

--- a/image/image.go
+++ b/image/image.go
@@ -96,8 +96,9 @@ func (i *Image) WholeImageSelection() Selection {
 //
 // DEPRECATED - this method will be removed in next release
 func (i *Image) Upload() {
-	if !i.acceleratedImageModified {
+	if !i.acceleratedImageModified || i.ramModified {
 		i.acceleratedImage.Upload(i.pixels)
+		i.ramModified = false
 	}
 }
 
@@ -367,6 +368,7 @@ func (l Lines) LineForWrite(line int) []Color {
 	if stop > len(l.image.pixels) || stop < 0 {
 		return []Color{}
 	}
+	l.image.ramModified = true
 	return l.image.pixels[start:stop]
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -292,10 +292,15 @@ func (s Selection) Lines() Lines {
 	if s.y < 0 {
 		yOffset = -s.y
 	}
+	xOffset := 0
+	if s.x < 0 {
+		xOffset = -s.x
+	}
 	return Lines{
 		y:       s.y,
 		length:  length,
 		image:   s.image,
+		xOffset: xOffset,
 		yOffset: yOffset,
 	}
 }
@@ -303,8 +308,8 @@ func (s Selection) Lines() Lines {
 type Lines struct {
 	y       int
 	length  int
-	xOffset int // X selection offset
-	yOffset int // Y selection offset
+	xOffset int
+	yOffset int
 	image   *Image
 }
 
@@ -313,7 +318,7 @@ func (l Lines) Length() int {
 }
 
 func (l Lines) XOffset() int {
-	return 0
+	return l.xOffset
 }
 
 func (l Lines) YOffset() int {

--- a/image/image.go
+++ b/image/image.go
@@ -349,9 +349,10 @@ func (l Lines) YOffset() int {
 // the len of returned slice might be lower than Selection width. The starting offset
 // can be read by executing Lines.XOffset().
 //
-// It is not safe to retain Line for future use. The image might be modified by
+// It is not safe to retain returned slice for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForWrite(line int) []Color {
+	// TODO Should download AcceleratedImage if it was modified first
 	pixels := l.line(line)
 	l.image.ramModified = true
 	return pixels
@@ -370,9 +371,10 @@ func (l Lines) LineForWrite(line int) []Color {
 // the len of returned slice might be lower than Selection width. The starting offset
 // can be read by executing Lines.XOffset().
 //
-// It is not safe to retain Line for future use. The image might be modified by
+// It is not safe to retain returned slice for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForRead(line int) []Color {
+	// TODO Should download AcceleratedImage if it was modified first
 	return l.line(line)
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -326,7 +326,16 @@ func (l Lines) YOffset() int {
 }
 
 func (l Lines) LineForWrite(y int) []Color {
-	return nil
+	imageY := y + l.y
+	if imageY < 0 {
+		panic("line out-of-bounds the image")
+	}
+	if imageY >= l.image.height {
+		panic("line out-of-bounds the image")
+	}
+	start := (l.image.heightMinusOne - y - l.y) * l.image.width
+	stop := start + l.image.width
+	return l.image.pixels[start:stop]
 }
 
 func (l Lines) LineForRead(y int) []Color {

--- a/image/image.go
+++ b/image/image.go
@@ -271,3 +271,22 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 		Image: s.image.acceleratedImage,
 	}
 }
+
+func (s Selection) Line(y int) Line {
+	return Line{}
+}
+
+type Line struct {
+}
+
+func (l Line) Width() int {
+	return 0
+}
+
+func (l Line) SetColor(x int, color Color) {
+
+}
+
+func (l Line) Color(x int) Color {
+	return Transparent
+}

--- a/image/image.go
+++ b/image/image.go
@@ -272,21 +272,49 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 	}
 }
 
+// Line returns all pixels in a line which can be used for efficient pixel processing.
+//
+// It is not safe to retain Line for future use. The image might be modified by
+// AcceleratedCommand and changes will not be reflected in cached Line.
 func (s Selection) Line(y int) Line {
-	return Line{}
+	start := (s.y+y)*s.width + s.x
+	stop := start + s.width
+	if start < 0 {
+		start = 0
+	}
+	if stop < 0 {
+		stop = 0
+	}
+	if start >= len(s.image.pixels) {
+		start = len(s.image.pixels) - 1
+	}
+	if stop >= len(s.image.pixels) {
+		stop = len(s.image.pixels) - 1
+	}
+	return Line{pixels: s.image.pixels[start:stop], width: s.image.width}
 }
 
 type Line struct {
+	x, width int
+	//image    *Image
+	pixels []Color
 }
 
 func (l Line) Width() int {
-	return 0
+	return len(l.pixels)
 }
 
 func (l Line) SetColor(x int, color Color) {
-
+	x = l.x + x
+	if x < 0 {
+		return
+	}
+	if x >= l.width {
+		return
+	}
+	l.pixels[x] = color
 }
 
 func (l Line) Color(x int) Color {
-	return Transparent
+	return l.pixels[x]
 }

--- a/image/image.go
+++ b/image/image.go
@@ -276,35 +276,48 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 }
 
 func (s Selection) Lines() Lines {
-	start := s.y
-	if start < 0 {
-		start = 0
+	startLine := s.y
+	if startLine < 0 {
+		startLine = 0
 	}
-	end := s.y + s.height
-	if end > s.image.height {
-		end = s.image.height
+	endLine := s.y + s.height
+	if endLine > s.image.height {
+		endLine = s.image.height
 	}
-	length := end - start
+	length := endLine - startLine
 	if length < 0 {
 		length = 0
 	}
+	yOffset := 0
+	if s.y < 0 {
+		yOffset = -s.y
+	}
 	return Lines{
-		y:      s.y,
-		length: length,
-		image:  s.image,
+		y:       s.y,
+		length:  length,
+		image:   s.image,
+		yOffset: yOffset,
 	}
 }
 
 type Lines struct {
 	y       int
 	length  int
-	XOffset int // X selection offset
-	YOffset int // Y selection offset
+	xOffset int // X selection offset
+	yOffset int // Y selection offset
 	image   *Image
 }
 
 func (l Lines) Length() int {
 	return l.length
+}
+
+func (l Lines) XOffset() int {
+	return 0
+}
+
+func (l Lines) YOffset() int {
+	return l.yOffset
 }
 
 func (l Lines) LineForWrite(y int) []Color {

--- a/image/image.go
+++ b/image/image.go
@@ -218,7 +218,6 @@ func (s Selection) SetColor(localX, localY int, color Color) {
 		return
 	}
 	s.image.pixels[index] = color
-	s.image.ramModified = true
 }
 
 // AcceleratedImageLocation is a location of a AcceleratedImage
@@ -296,6 +295,10 @@ func (s Selection) Lines() Lines {
 	if s.x < 0 {
 		xOffset = -s.x
 	}
+	width := s.width - xOffset
+	if width > s.image.width {
+		width = s.image.width - xOffset
+	}
 	return Lines{
 		startY:  s.y,
 		startX:  s.x,
@@ -303,12 +306,14 @@ func (s Selection) Lines() Lines {
 		image:   s.image,
 		xOffset: xOffset,
 		yOffset: yOffset,
+		width:   width,
 	}
 }
 
 type Lines struct {
 	startY  int
 	startX  int
+	width   int
 	length  int
 	xOffset int
 	yOffset int
@@ -338,11 +343,11 @@ func (l Lines) LineForWrite(line int) []Color {
 		panic("line out-of-bounds the image")
 	}
 	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.startX
-	stop := start + l.image.width
+	stop := start + l.width
 	if start < 0 {
 		start = 0
 	}
-	if stop > len(l.image.pixels) {
+	if stop > len(l.image.pixels) || stop < 0 {
 		return []Color{}
 	}
 	return l.image.pixels[start:stop]
@@ -359,11 +364,11 @@ func (l Lines) LineForRead(line int) []Color {
 		panic("line out-of-bounds the image")
 	}
 	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.startX
-	stop := start + l.image.width
+	stop := start + l.width
 	if start < 0 {
 		start = 0
 	}
-	if stop > len(l.image.pixels) {
+	if stop > len(l.image.pixels) || stop < 0 {
 		return []Color{}
 	}
 	return l.image.pixels[start:stop]

--- a/image/image.go
+++ b/image/image.go
@@ -325,28 +325,32 @@ func (l Lines) YOffset() int {
 	return l.yOffset
 }
 
-func (l Lines) LineForWrite(y int) []Color {
-	imageY := y + l.y
-	if imageY < 0 {
+func (l Lines) LineForWrite(line int) []Color {
+	if l.Length() == 0 {
+		panic("zero lines length")
+	}
+	if line < 0 {
+		panic("negative line")
+	}
+	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	if imageY >= l.image.height {
-		panic("line out-of-bounds the image")
-	}
-	start := (l.image.heightMinusOne - y - l.y) * l.image.width
+	start := (l.image.heightMinusOne - line - l.y) * l.image.width
 	stop := start + l.image.width
 	return l.image.pixels[start:stop]
 }
 
-func (l Lines) LineForRead(y int) []Color {
-	imageY := y + l.y
-	if imageY < 0 {
+func (l Lines) LineForRead(line int) []Color {
+	if l.Length() == 0 {
+		panic("zero lines length")
+	}
+	if line < 0 {
+		panic("negative line")
+	}
+	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	if imageY >= l.image.height {
-		panic("line out-of-bounds the image")
-	}
-	start := (l.image.heightMinusOne - y - l.y) * l.image.width
+	start := (l.image.heightMinusOne - line - l.y) * l.image.width
 	stop := start + l.image.width
 	return l.image.pixels[start:stop]
 }

--- a/image/image.go
+++ b/image/image.go
@@ -280,7 +280,7 @@ func (s Selection) Lines() Lines {
 	if s.y < 0 {
 		length += s.y
 	}
-	if s.image.height < length+s.y {
+	if s.image.height-s.y < length {
 		length = s.image.height - s.y
 	}
 	return Lines{

--- a/image/image.go
+++ b/image/image.go
@@ -277,8 +277,8 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 // It is not safe to retain Line for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in cached Line.
 func (s Selection) Line(y int) Line {
-	start := (s.y+y)*s.width + s.x
-	stop := start + s.width
+	start := (s.y + y) * s.image.width
+	stop := start + s.image.width
 	if start < 0 {
 		start = 0
 	}
@@ -291,12 +291,13 @@ func (s Selection) Line(y int) Line {
 	if stop >= len(s.image.pixels) {
 		stop = len(s.image.pixels) - 1
 	}
-	return Line{pixels: s.image.pixels[start:stop], width: s.image.width}
+	return Line{
+		pixels: s.image.pixels[start:stop],
+		x:      s.x}
 }
 
 type Line struct {
-	x, width int
-	//image    *Image
+	x      int
 	pixels []Color
 }
 
@@ -309,12 +310,19 @@ func (l Line) SetColor(x int, color Color) {
 	if x < 0 {
 		return
 	}
-	if x >= l.width {
+	if x >= len(l.pixels) {
 		return
 	}
 	l.pixels[x] = color
 }
 
 func (l Line) Color(x int) Color {
+	x = l.x + x
+	if x < 0 {
+		return Transparent
+	}
+	if x >= len(l.pixels) {
+		return Transparent
+	}
 	return l.pixels[x]
 }

--- a/image/image.go
+++ b/image/image.go
@@ -276,12 +276,17 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 }
 
 func (s Selection) Lines() Lines {
-	length := s.height
-	if s.y < 0 {
-		length += s.y
+	start := s.y
+	if start < 0 {
+		start = 0
 	}
-	if s.image.height-s.y < length {
-		length = s.image.height - s.y
+	end := s.y + s.height
+	if end > s.image.height {
+		end = s.image.height
+	}
+	length := end - start
+	if length < 0 {
+		length = 0
 	}
 	return Lines{
 		y:      s.y,

--- a/image/image.go
+++ b/image/image.go
@@ -275,6 +275,50 @@ func (s Selection) toAcceleratedImageSelection() AcceleratedImageSelection {
 	}
 }
 
+func (s Selection) Lines() Lines {
+	length := s.height
+	if s.y < 0 {
+		length += s.y
+	}
+	if s.image.height < length+s.y {
+		length = s.image.height - s.y
+	}
+	return Lines{
+		y:      s.y,
+		length: length,
+		image:  s.image,
+	}
+}
+
+type Lines struct {
+	y       int
+	length  int
+	XOffset int // X selection offset
+	YOffset int // Y selection offset
+	image   *Image
+}
+
+func (l Lines) Length() int {
+	return l.length
+}
+
+func (l Lines) LineForWrite(y int) []Color {
+	return nil
+}
+
+func (l Lines) LineForRead(y int) []Color {
+	imageY := y + l.y
+	if imageY < 0 {
+		panic("line out-of-bounds the image")
+	}
+	if imageY >= l.image.height {
+		panic("line out-of-bounds the image")
+	}
+	start := 0
+	stop := l.image.width
+	return l.image.pixels[start:stop]
+}
+
 // LineForRead returns Selection pixels in a given line which can be used for
 // efficient pixel processing. It was created solely for performance reasons.
 //

--- a/image/image.go
+++ b/image/image.go
@@ -96,7 +96,7 @@ func (i *Image) WholeImageSelection() Selection {
 //
 // DEPRECATED - this method will be removed in next release
 func (i *Image) Upload() {
-	if !i.acceleratedImageModified || i.ramModified {
+	if i.ramModified {
 		i.acceleratedImage.Upload(i.pixels)
 		i.ramModified = false
 	}
@@ -218,6 +218,7 @@ func (s Selection) SetColor(localX, localY int, color Color) {
 	if index >= len(s.image.pixels) {
 		return
 	}
+	s.image.ramModified = true
 	s.image.pixels[index] = color
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -53,9 +53,10 @@ func New(width, height int, acceleratedImage AcceleratedImage) *Image {
 // The cost of creating an Image is huge therefore new images should be created
 // sporadically, ideally when the application starts.
 type Image struct {
-	width                    int
-	height                   int
-	heightMinusOne           int
+	width          int
+	height         int
+	heightMinusOne int
+	// pixel colors line by line, starting from the bottom
 	pixels                   []Color
 	acceleratedImage         AcceleratedImage
 	selectionsCache          []AcceleratedImageSelection
@@ -301,10 +302,12 @@ func (s Selection) LineForRead(y int) (slice []Color, offset int) {
 	//	s.image.acceleratedImage.Download(s.image.pixels)
 	//	s.image.acceleratedImageModified = false
 	//}
+	start := 0
 	//start := (s.y+y)*s.image.width + s.x
+	stop := s.image.width
 	//stop := start + s.width
 	//return s.image.pixels[start:stop], 0
-	return nil, 0
+	return s.image.pixels[start:stop], 0
 }
 
 // LineForWrite returns Selection pixels in a given line which can be used for

--- a/image/image.go
+++ b/image/image.go
@@ -297,7 +297,8 @@ func (s Selection) Lines() Lines {
 		xOffset = -s.x
 	}
 	return Lines{
-		y:       s.y,
+		startY:  s.y,
+		startX:  s.x,
 		length:  length,
 		image:   s.image,
 		xOffset: xOffset,
@@ -306,7 +307,8 @@ func (s Selection) Lines() Lines {
 }
 
 type Lines struct {
-	y       int
+	startY  int
+	startX  int
 	length  int
 	xOffset int
 	yOffset int
@@ -335,8 +337,14 @@ func (l Lines) LineForWrite(line int) []Color {
 	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	start := (l.image.heightMinusOne - line - l.y) * l.image.width
-	stop := start + l.image.width
+	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.xOffset
+	stop := start + l.image.width - l.xOffset
+	if start < 0 {
+		start = 0
+	}
+	if stop < start {
+		return []Color{}
+	}
 	return l.image.pixels[start:stop]
 }
 
@@ -350,8 +358,14 @@ func (l Lines) LineForRead(line int) []Color {
 	if line >= l.Length() {
 		panic("line out-of-bounds the image")
 	}
-	start := (l.image.heightMinusOne - line - l.y) * l.image.width
-	stop := start + l.image.width
+	start := (l.image.heightMinusOne-line-l.startY)*l.image.width + l.xOffset
+	stop := start + l.image.width - l.xOffset
+	if start < 0 {
+		start = 0
+	}
+	if stop < start {
+		return []Color{}
+	}
 	return l.image.pixels[start:stop]
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -337,8 +337,8 @@ func (l Lines) LineForRead(y int) []Color {
 	if imageY >= l.image.height {
 		panic("line out-of-bounds the image")
 	}
-	start := 0
-	stop := l.image.width
+	start := (l.image.heightMinusOne - y - l.y) * l.image.width
+	stop := start + l.image.width
 	return l.image.pixels[start:stop]
 }
 

--- a/image/image.go
+++ b/image/image.go
@@ -352,8 +352,6 @@ func (l Lines) YOffset() int {
 // It is not safe to retain returned slice for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForWrite(line int) []Color {
-	// TODO Should download AcceleratedImage if it was modified first
-
 	pixels := l.line(line)
 	l.image.ramModified = true
 	return pixels
@@ -375,7 +373,6 @@ func (l Lines) LineForWrite(line int) []Color {
 // It is not safe to retain returned slice for future use. The image might be modified by
 // AcceleratedCommand and changes will not be reflected in a slice.
 func (l Lines) LineForRead(line int) []Color {
-	// TODO Should download AcceleratedImage if it was modified first
 	return l.line(line)
 }
 
@@ -396,6 +393,10 @@ func (l Lines) line(line int) []Color {
 	}
 	if stop > len(l.image.pixels) || stop < 0 {
 		return []Color{}
+	}
+	if l.image.acceleratedImageModified {
+		l.image.acceleratedImage.Download(l.image.pixels)
+		l.image.acceleratedImageModified = false
 	}
 	return l.image.pixels[start:stop]
 }

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkSelection_Color(b *testing.B) {
 	}
 }
 
-func BenchmarkLine_SetColor(b *testing.B) {
+func BenchmarkSelection_LineForWrite(b *testing.B) {
 	var (
 		color     = image.RGBA(10, 20, 30, 40)
 		img       = image.New(1920, 1080, acceleratedImageStub{})
@@ -54,16 +54,15 @@ func BenchmarkLine_SetColor(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
-			line := selection.Line(y)
-			width := line.Width()
-			for x := 0; x < width; x++ {
-				line.SetColor(x, color)
+			line := selection.LineForWrite(y)
+			for x := 0; x < len(line); x++ {
+				line[x] = color
 			}
 		}
 	}
 }
 
-func BenchmarkLine_Color(b *testing.B) {
+func BenchmarkSelection_LineForRead(b *testing.B) {
 	var (
 		img       = image.New(1920, 1080, acceleratedImageStub{})
 		selection = img.WholeImageSelection()
@@ -73,9 +72,9 @@ func BenchmarkLine_Color(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
-			line := selection.Line(y)
-			for x := 0; x < line.Width(); x++ {
-				line.Color(x)
+			line := selection.LineForRead(y)
+			for x := 0; x < len(line); x++ {
+				_ = line[x]
 			}
 		}
 	}

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkSelection_LineForWrite(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
-			line := selection.LineForWrite(y)
+			line, _ := selection.LineForWrite(y)
 			for x := 0; x < len(line); x++ {
 				line[x] = color
 			}
@@ -72,7 +72,7 @@ func BenchmarkSelection_LineForRead(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
-			line := selection.LineForRead(y)
+			line, _ := selection.LineForRead(y)
 			for x := 0; x < len(line); x++ {
 				_ = line[x]
 			}

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -43,6 +43,43 @@ func BenchmarkSelection_Color(b *testing.B) {
 	}
 }
 
+func BenchmarkSelection_Line_SetColor(b *testing.B) {
+	var (
+		color     = image.RGBA(10, 20, 30, 40)
+		img       = image.New(1920, 1080, acceleratedImageStub{})
+		selection = img.WholeImageSelection()
+		height    = selection.Height()
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for y := 0; y < height; y++ {
+			line := selection.Line(y)
+			for x := 0; x < line.Width(); x++ {
+				line.SetColor(x, color)
+			}
+		}
+	}
+}
+
+func BenchmarkSelection_Line_Color(b *testing.B) {
+	var (
+		img       = image.New(1920, 1080, acceleratedImageStub{})
+		selection = img.WholeImageSelection()
+		height    = selection.Height()
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for y := 0; y < height; y++ {
+			line := selection.Line(y)
+			for x := 0; x < line.Width(); x++ {
+				line.Color(x)
+			}
+		}
+	}
+}
+
 // Must be 0 allocs/op
 func BenchmarkImage_Selection(b *testing.B) {
 	var (

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkSelection_Color(b *testing.B) {
 	}
 }
 
-func BenchmarkSelection_Line_SetColor(b *testing.B) {
+func BenchmarkLine_SetColor(b *testing.B) {
 	var (
 		color     = image.RGBA(10, 20, 30, 40)
 		img       = image.New(1920, 1080, acceleratedImageStub{})
@@ -62,7 +62,7 @@ func BenchmarkSelection_Line_SetColor(b *testing.B) {
 	}
 }
 
-func BenchmarkSelection_Line_Color(b *testing.B) {
+func BenchmarkLine_Color(b *testing.B) {
 	var (
 		img       = image.New(1920, 1080, acceleratedImageStub{})
 		selection = img.WholeImageSelection()

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -62,46 +62,21 @@ func BenchmarkLines_LineForWrite(b *testing.B) {
 	}
 }
 
-func BenchmarkSelection_LineForWrite(b *testing.B) {
+func BenchmarkLines_LineForRead(b *testing.B) {
 	var (
-		color     = image.RGBA(10, 20, 30, 40)
 		img       = image.New(1920, 1080, acceleratedImageStub{})
 		selection = img.WholeImageSelection()
-		height    = selection.Height()
 	)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for y := 0; y < height; y++ {
-			line, _ := selection.LineForWrite(y)
-			for x := 0; x < len(line); x++ {
-				line[x] = color
-			}
-		}
-	}
-}
-
-func BenchmarkSelection_LineForRead(b *testing.B) {
-	var (
-		img       = image.New(1920, 1080, acceleratedImageStub{})
-		selection = img.WholeImageSelection()
-		height    = selection.Height()
-	)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for y := 0; y < height; y++ {
-			line, _ := selection.LineForRead(y)
+		lines := selection.Lines()
+		for y := 0; y < lines.Length(); y++ {
+			line := lines.LineForRead(y)
 			for x := 0; x < len(line); x++ {
 				_ = line[x]
 			}
 		}
-	}
-}
-
-func BenchmarkLines_LineForRead(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-
 	}
 }
 

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -55,7 +55,8 @@ func BenchmarkLine_SetColor(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for y := 0; y < height; y++ {
 			line := selection.Line(y)
-			for x := 0; x < line.Width(); x++ {
+			width := line.Width()
+			for x := 0; x < width; x++ {
 				line.SetColor(x, color)
 			}
 		}

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -43,6 +43,25 @@ func BenchmarkSelection_Color(b *testing.B) {
 	}
 }
 
+func BenchmarkLines_LineForWrite(b *testing.B) {
+	var (
+		color     = image.RGBA(10, 20, 30, 40)
+		img       = image.New(1920, 1080, acceleratedImageStub{})
+		selection = img.WholeImageSelection()
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lines := selection.Lines()
+		for y := 0; y < lines.Length(); y++ {
+			line := lines.LineForWrite(y)
+			for x := 0; x < len(line); x++ {
+				line[x] = color
+			}
+		}
+	}
+}
+
 func BenchmarkSelection_LineForWrite(b *testing.B) {
 	var (
 		color     = image.RGBA(10, 20, 30, 40)
@@ -77,6 +96,12 @@ func BenchmarkSelection_LineForRead(b *testing.B) {
 				_ = line[x]
 			}
 		}
+	}
+}
+
+func BenchmarkLines_LineForRead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+
 	}
 }
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -903,6 +903,39 @@ func TestLines_YOffset(t *testing.T) {
 	}
 }
 
+func TestLines_XOffset(t *testing.T) {
+	img := newImage(0, 0)
+	tests := map[string]struct {
+		selection       image.Selection
+		expectedXOffset int
+	}{
+		"-1": {
+			selection:       img.Selection(-1, 0),
+			expectedXOffset: 1,
+		},
+		"-2": {
+			selection:       img.Selection(-2, 0),
+			expectedXOffset: 2,
+		},
+		"0": {
+			selection:       img.Selection(0, 0),
+			expectedXOffset: 0,
+		},
+		"1": {
+			selection:       img.Selection(1, 0),
+			expectedXOffset: 0,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lines := test.selection.Lines()
+			// when
+			offset := lines.XOffset()
+			assert.Equal(t, test.expectedXOffset, offset)
+		})
+	}
+}
+
 // TODO Reuse
 func TestSelection_LineForRead(t *testing.T) {
 	t.Run("should panic when line is out-of-bounds the image", func(t *testing.T) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -801,7 +801,57 @@ func TestSelection_Modify(t *testing.T) {
 		// then
 		assert.Equal(t, [][]image.Color{{color}}, accImg.PixelsTable())
 	})
+}
 
+func TestLine_Width(t *testing.T) {
+	t.Skip()
+	img0x0 := newImage(0, 0)
+	img1x1 := newImage(1, 1)
+
+	tests := map[string]struct {
+		image         *image.Image
+		line          image.Line
+		expectedWidth int
+	}{
+		"0x0": {
+			image:         img0x0,
+			line:          img0x0.Selection(0, 0).Line(0),
+			expectedWidth: 0,
+		},
+		"1x1, selection 1,0": {
+			image:         img1x1,
+			line:          img1x1.Selection(1, 0).Line(0),
+			expectedWidth: 0,
+		},
+		"1x1, selection 0,1": {
+			image:         img1x1,
+			line:          img1x1.Selection(0, 1).Line(0),
+			expectedWidth: 0,
+		},
+		"1x1, selection -1,0": {
+			image:         img1x1,
+			line:          img1x1.Selection(-1, 0).Line(0),
+			expectedWidth: 1,
+		},
+		"1x1, selection 0,0": {
+			image:         img1x1,
+			line:          img1x1.Selection(0, 0).Line(0),
+			expectedWidth: 1,
+		},
+		"1x1, nested selection": {
+			image:         img1x1,
+			line:          img1x1.Selection(1, 0).Selection(-1, 0).Line(0),
+			expectedWidth: 1,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// when
+			width := test.line.Width()
+			// then
+			assert.Equal(t, test.expectedWidth, width)
+		})
+	}
 }
 
 func assertColors(t *testing.T, selection image.Selection, expectedColorLines [][]image.Color) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1,6 +1,7 @@
 package image_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -803,6 +804,7 @@ func TestSelection_Modify(t *testing.T) {
 	})
 }
 
+// TODO Reuse
 func TestSelection_LineForRead(t *testing.T) {
 	t.Run("should panic when line is out-of-bounds the image", func(t *testing.T) {
 		image0x0 := newImage(0, 0)
@@ -858,14 +860,73 @@ func TestSelection_LineForRead(t *testing.T) {
 		}
 	})
 	t.Run("should return line", func(t *testing.T) {
-		img := newImage(1, 1)
-		selection := img.Selection(0, 0)
-		// when
-		line, offset := selection.LineForRead(0)
-		// then
-		require.NotNil(t, line)
-		assert.Equal(t, []image.Color{transparent}, line)
-		assert.Equal(t, 0, offset)
+		color1 := image.RGBA(10, 20, 30, 40)
+		color2 := image.RGBA(50, 50, 60, 70)
+		//color3 := image.RGBA(80, 90, 100, 110)
+		//color4 := image.RGBA(120, 130, 140, 150)
+
+		image1x1 := newImage(1, 1)
+		image1x1.Selection(0, 0).SetColor(0, 0, color1)
+
+		image1x2 := newImage(1, 2)
+		image1x2.Selection(0, 0).SetColor(0, 0, color1)
+		image1x2.Selection(0, 1).SetColor(0, 0, color2)
+
+		tests := map[string]struct {
+			image          *image.Image
+			selection      image.Selection
+			line           int
+			expectedOffset int
+			expected       []image.Color
+		}{
+			"1": {
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 0),
+				line:           0,
+				expectedOffset: 0,
+				expected:       []image.Color{color1},
+			},
+			"2": {
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 1),
+				line:           -1,
+				expectedOffset: 0,
+				expected:       []image.Color{color1},
+			},
+			"3": {
+				image:          image1x2,
+				selection:      image1x2.Selection(0, 0),
+				line:           1,
+				expectedOffset: 0,
+				expected:       []image.Color{color2},
+			},
+			"4": {
+				image:          image1x2,
+				selection:      image1x2.Selection(0, 1),
+				line:           0,
+				expectedOffset: 0,
+				expected:       []image.Color{color2},
+			},
+			//"5": {
+			//	image:          image1x1,
+			//	selection:      image1x1.Selection(1, 0),
+			//	line:           0,
+			//	expectedOffset: 0,
+			//	expected:       []image.Color{},
+			//},
+		}
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				// when
+				line, offset := test.selection.LineForRead(test.line)
+				// then
+				require.NotNil(t, line)
+				assert.Equal(t, test.expectedOffset, offset)
+				fmt.Println(line)
+				assert.Equal(t, test.expected, line)
+			})
+		}
+
 	})
 }
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -833,9 +833,19 @@ func TestSelection_Lines(t *testing.T) {
 				selection:        image1x1.Selection(0, -1).WithSize(0, 1),
 				expectedLinesLen: 0,
 			},
+			"selection y -2, height 1": {
+				image:            image1x1,
+				selection:        image1x1.Selection(0, -2).WithSize(0, 1),
+				expectedLinesLen: 0,
+			},
 			"selection height 1": {
 				image:            image1x1,
 				selection:        image1x1.Selection(0, 0).WithSize(0, 1),
+				expectedLinesLen: 1,
+			},
+			"selection height 2": {
+				image:            image1x1,
+				selection:        image1x1.Selection(0, 0).WithSize(0, 2),
 				expectedLinesLen: 1,
 			},
 			"selection y -1, height 2": {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1129,20 +1129,8 @@ func TestSelection_LineForXXX(t *testing.T) {
 						expected:  []image.Color{color1},
 					},
 					"8": {
-						image:     image1x2,
-						selection: image1x2.Selection(0, 0).WithSize(1, 2),
-						line:      1,
-						expected:  []image.Color{color2},
-					},
-					"9": {
 						image:     image2x1,
 						selection: image2x1.Selection(1, 0).WithSize(1, 1),
-						line:      0,
-						expected:  []image.Color{color2},
-					},
-					"10": {
-						image:     image1x2,
-						selection: image1x2.Selection(0, 1).WithSize(1, 1),
 						line:      0,
 						expected:  []image.Color{color2},
 					},

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -803,71 +803,104 @@ func TestSelection_Modify(t *testing.T) {
 	})
 }
 
-func TestSelection_Lines(t *testing.T) {
-	t.Run("should return lines", func(t *testing.T) {
+func TestLines_Length(t *testing.T) {
+	t.Run("should return lines length", func(t *testing.T) {
 		image0x0 := newImage(0, 0)
 		image1x1 := newImage(1, 1)
 		image1x2 := newImage(1, 2)
 		tests := map[string]struct {
-			image            *image.Image
-			selection        image.Selection
-			expectedLinesLen int
+			image          *image.Image
+			selection      image.Selection
+			expectedLength int
 		}{
 			"image height 0": {
-				image:            image0x0,
-				selection:        image0x0.Selection(0, 0).WithSize(0, 1),
-				expectedLinesLen: 0,
+				image:          image0x0,
+				selection:      image0x0.Selection(0, 0).WithSize(0, 1),
+				expectedLength: 0,
 			},
 			"selection height 0": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, 0).WithSize(0, 0),
-				expectedLinesLen: 0,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 0).WithSize(0, 0),
+				expectedLength: 0,
 			},
 			"selection y 1, height 1": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, 1).WithSize(0, 1),
-				expectedLinesLen: 0,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 1).WithSize(0, 1),
+				expectedLength: 0,
 			},
 			"selection y -1, height 1": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, -1).WithSize(0, 1),
-				expectedLinesLen: 0,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, -1).WithSize(0, 1),
+				expectedLength: 0,
 			},
 			"selection y -2, height 1": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, -2).WithSize(0, 1),
-				expectedLinesLen: 0,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, -2).WithSize(0, 1),
+				expectedLength: 0,
 			},
 			"selection height 1": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, 0).WithSize(0, 1),
-				expectedLinesLen: 1,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 0).WithSize(0, 1),
+				expectedLength: 1,
 			},
 			"selection height 2": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, 0).WithSize(0, 2),
-				expectedLinesLen: 1,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, 0).WithSize(0, 2),
+				expectedLength: 1,
 			},
 			"selection y -1, height 2": {
-				image:            image1x1,
-				selection:        image1x1.Selection(0, -1).WithSize(0, 2),
-				expectedLinesLen: 1,
+				image:          image1x1,
+				selection:      image1x1.Selection(0, -1).WithSize(0, 2),
+				expectedLength: 1,
 			},
 			"image height 2, selection y 1, height 1": {
-				image:            image1x2,
-				selection:        image1x2.Selection(0, 1).WithSize(0, 1),
-				expectedLinesLen: 1,
+				image:          image1x2,
+				selection:      image1x2.Selection(0, 1).WithSize(0, 1),
+				expectedLength: 1,
 			},
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
-				// when
 				lines := test.selection.Lines()
-				// then
-				assert.Equal(t, test.expectedLinesLen, lines.Length())
+				// when
+				length := lines.Length()
+				assert.Equal(t, test.expectedLength, length)
 			})
 		}
 	})
+}
+
+func TestLines_YOffset(t *testing.T) {
+	img := newImage(0, 0)
+	tests := map[string]struct {
+		selection       image.Selection
+		expectedYOffset int
+	}{
+		"-1": {
+			selection:       img.Selection(0, -1),
+			expectedYOffset: 1,
+		},
+		"-2": {
+			selection:       img.Selection(0, -2),
+			expectedYOffset: 2,
+		},
+		"0": {
+			selection:       img.Selection(0, 0),
+			expectedYOffset: 0,
+		},
+		"1": {
+			selection:       img.Selection(0, 1),
+			expectedYOffset: 0,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			lines := test.selection.Lines()
+			// when
+			offset := lines.YOffset()
+			assert.Equal(t, test.expectedYOffset, offset)
+		})
+	}
 }
 
 // TODO Reuse

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1028,25 +1028,25 @@ func TestSelection_Lines(t *testing.T) {
 				}{
 					"1": {
 						image:     image1x1,
-						selection: image1x1.Selection(0, 0).WithSize(0, 1),
+						selection: image1x1.Selection(0, 0).WithSize(1, 1),
 						line:      0,
 						expected:  []image.Color{color1},
 					},
 					"2": {
 						image:     image1x2,
-						selection: image1x2.Selection(0, 0).WithSize(0, 2),
+						selection: image1x2.Selection(0, 0).WithSize(1, 2),
 						line:      1,
 						expected:  []image.Color{color2},
 					},
 					"3": {
 						image:     image1x2,
-						selection: image1x2.Selection(0, 1).WithSize(0, 1),
+						selection: image1x2.Selection(0, 1).WithSize(1, 1),
 						line:      0,
 						expected:  []image.Color{color2},
 					},
 					"4": {
 						image:     image1x2,
-						selection: image1x2.Selection(0, 0).WithSize(0, 2),
+						selection: image1x2.Selection(0, 0).WithSize(1, 2),
 						line:      0,
 						expected:  []image.Color{color1},
 					},
@@ -1061,6 +1061,18 @@ func TestSelection_Lines(t *testing.T) {
 						selection: image1x1.Selection(-1, 0).WithSize(1, 1),
 						line:      0,
 						expected:  []image.Color{},
+					},
+					"7": {
+						image:     image2x1,
+						selection: image2x1.Selection(0, 0).WithSize(1, 1),
+						line:      0,
+						expected:  []image.Color{color1},
+					},
+					"8": {
+						image:     image1x2,
+						selection: image1x2.Selection(0, 0).WithSize(1, 2),
+						line:      1,
+						expected:  []image.Color{color2},
 					},
 				}
 				for name, test := range tests {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1011,8 +1011,14 @@ func TestSelection_Lines(t *testing.T) {
 				image1x1.Selection(0, 0).SetColor(0, 0, color1)
 
 				image1x2 := newImage(1, 2)
-				image1x2.Selection(0, 0).SetColor(0, 0, color1)
-				image1x2.Selection(0, 1).SetColor(0, 0, color2)
+				image1x2Selection := image1x2.WholeImageSelection()
+				image1x2Selection.SetColor(0, 0, color1)
+				image1x2Selection.SetColor(0, 1, color2)
+
+				image2x1 := newImage(2, 1)
+				image2x1Selection := image2x1.WholeImageSelection()
+				image2x1Selection.SetColor(0, 0, color1)
+				image2x1Selection.SetColor(1, 0, color2)
 
 				tests := map[string]struct {
 					image     *image.Image
@@ -1043,6 +1049,18 @@ func TestSelection_Lines(t *testing.T) {
 						selection: image1x2.Selection(0, 0).WithSize(0, 2),
 						line:      0,
 						expected:  []image.Color{color1},
+					},
+					"5": {
+						image:     image1x1,
+						selection: image1x1.Selection(1, 0).WithSize(1, 1),
+						line:      0,
+						expected:  []image.Color{},
+					},
+					"6": {
+						image:     image1x1,
+						selection: image1x1.Selection(-1, 0).WithSize(1, 1),
+						line:      0,
+						expected:  []image.Color{},
 					},
 				}
 				for name, test := range tests {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1035,13 +1035,12 @@ func TestSelection_LineForRead(t *testing.T) {
 				line:      0,
 				expected:  []image.Color{color2},
 			},
-			//"5": {
-			//	image:          image1x1,
-			//	selection:      image1x1.Selection(1, 0),
-			//	line:           0,
-			//	expectedOffset: 0,
-			//	expected:       []image.Color{},
-			//},
+			"5": {
+				image:     image1x2,
+				selection: image1x2.Selection(0, 0),
+				line:      0,
+				expected:  []image.Color{color1},
+			},
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -803,6 +803,72 @@ func TestSelection_Modify(t *testing.T) {
 	})
 }
 
+func TestSelection_LineForRead(t *testing.T) {
+	t.Run("should panic when line is out-of-bounds the image", func(t *testing.T) {
+		image0x0 := newImage(0, 0)
+		image1x1 := newImage(1, 1)
+		tests := map[string]struct {
+			line      int
+			image     *image.Image
+			selection image.Selection
+		}{
+			"image 0x0, line 0": {
+				image:     image0x0,
+				selection: image0x0.Selection(0, 0),
+				line:      0,
+			},
+			"image 0x0, line -1": {
+				image:     image0x0,
+				selection: image0x0.Selection(0, 0),
+				line:      -1,
+			},
+			"image 0x0": {
+				image:     image0x0,
+				selection: image0x0.Selection(0, 0),
+				line:      1,
+			},
+			"image 1x1, line -1": {
+				image:     image1x1,
+				selection: image1x1.Selection(0, 0),
+				line:      -1,
+			},
+			"image 1x1, line 1": {
+				image:     image1x1,
+				selection: image1x1.Selection(0, 0),
+				line:      1,
+			},
+			"image 1x1, selection with y=1, line 0": {
+				image:     image1x1,
+				selection: image1x1.Selection(0, 1),
+				line:      0,
+			},
+			"image 1x1, selection with y=-1, line 0": {
+				image:     image1x1,
+				selection: image1x1.Selection(0, -1),
+				line:      0,
+			},
+		}
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				assert.Panics(t, func() {
+					// when
+					test.selection.LineForRead(test.line)
+				})
+			})
+		}
+	})
+	t.Run("should return line", func(t *testing.T) {
+		img := newImage(1, 1)
+		selection := img.Selection(0, 0)
+		// when
+		line, offset := selection.LineForRead(0)
+		// then
+		require.NotNil(t, line)
+		assert.Equal(t, []image.Color{transparent}, line)
+		assert.Equal(t, 0, offset)
+	})
+}
+
 func assertColors(t *testing.T, selection image.Selection, expectedColorLines [][]image.Color) {
 	assert.Equal(t, len(expectedColorLines), selection.Height(), "number of lines should be equal to selection height")
 	for y := 0; y < selection.Height(); y++ {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -803,57 +803,6 @@ func TestSelection_Modify(t *testing.T) {
 	})
 }
 
-func TestLine_Width(t *testing.T) {
-	t.Skip()
-	img0x0 := newImage(0, 0)
-	img1x1 := newImage(1, 1)
-
-	tests := map[string]struct {
-		image         *image.Image
-		line          image.Line
-		expectedWidth int
-	}{
-		"0x0": {
-			image:         img0x0,
-			line:          img0x0.Selection(0, 0).Line(0),
-			expectedWidth: 0,
-		},
-		"1x1, selection 1,0": {
-			image:         img1x1,
-			line:          img1x1.Selection(1, 0).Line(0),
-			expectedWidth: 0,
-		},
-		"1x1, selection 0,1": {
-			image:         img1x1,
-			line:          img1x1.Selection(0, 1).Line(0),
-			expectedWidth: 0,
-		},
-		"1x1, selection -1,0": {
-			image:         img1x1,
-			line:          img1x1.Selection(-1, 0).Line(0),
-			expectedWidth: 1,
-		},
-		"1x1, selection 0,0": {
-			image:         img1x1,
-			line:          img1x1.Selection(0, 0).Line(0),
-			expectedWidth: 1,
-		},
-		"1x1, nested selection": {
-			image:         img1x1,
-			line:          img1x1.Selection(1, 0).Selection(-1, 0).Line(0),
-			expectedWidth: 1,
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			// when
-			width := test.line.Width()
-			// then
-			assert.Equal(t, test.expectedWidth, width)
-		})
-	}
-}
-
 func assertColors(t *testing.T, selection image.Selection, expectedColorLines [][]image.Color) {
 	assert.Equal(t, len(expectedColorLines), selection.Height(), "number of lines should be equal to selection height")
 	for y := 0; y < selection.Height(); y++ {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -946,45 +946,51 @@ func TestSelection_Lines(t *testing.T) {
 			t.Run("should panic when line is out-of-bounds the image", func(t *testing.T) {
 				image0x0 := newImage(0, 0)
 				image1x1 := newImage(1, 1)
+				image1x2 := newImage(1, 2)
 				tests := map[string]struct {
 					line      int
 					image     *image.Image
 					selection image.Selection
 				}{
-					"image 0x0, line 0": {
-						image:     image0x0,
-						selection: image0x0.Selection(0, 0),
+					"selection height 0": {
+						image:     image1x1,
+						selection: image1x1.Selection(0, 0).WithSize(0, 0),
 						line:      0,
 					},
-					"image 0x0, line -1": {
+					"image height 0": {
 						image:     image0x0,
-						selection: image0x0.Selection(0, 0),
+						selection: image0x0.Selection(0, 0).WithSize(0, 1),
+						line:      0,
+					},
+					"line negative": {
+						image:     image1x1,
+						selection: image1x1.Selection(0, 0).WithSize(0, 1),
 						line:      -1,
 					},
-					"image 0x0": {
-						image:     image0x0,
-						selection: image0x0.Selection(0, 0),
+					"line equal to selection height": {
+						image:     image1x1,
+						selection: image1x1.Selection(0, 0).WithSize(0, 1),
 						line:      1,
 					},
-					"image 1x1, line -1": {
+					"line higher than selection height": {
 						image:     image1x1,
-						selection: image1x1.Selection(0, 0),
-						line:      -1,
+						selection: image1x1.Selection(0, 0).WithSize(0, 1),
+						line:      2,
 					},
-					"image 1x1, line 1": {
+					"line higher than image height": {
 						image:     image1x1,
-						selection: image1x1.Selection(0, 0),
+						selection: image1x1.Selection(0, 1).WithSize(0, 1),
+						line:      0,
+					},
+					"line above the image": {
+						image:     image1x1,
+						selection: image1x1.Selection(0, -1).WithSize(0, 1),
+						line:      0,
+					},
+					"line higher than selection height but inside image": {
+						image:     image1x2,
+						selection: image1x2.Selection(0, 0).WithSize(0, 1),
 						line:      1,
-					},
-					"image 1x1, selection with y=1, line 0": {
-						image:     image1x1,
-						selection: image1x1.Selection(0, 1),
-						line:      0,
-					},
-					"image 1x1, selection with y=-1, line 0": {
-						image:     image1x1,
-						selection: image1x1.Selection(0, -1),
-						line:      0,
 					},
 				}
 				for name, test := range tests {
@@ -1016,31 +1022,25 @@ func TestSelection_Lines(t *testing.T) {
 				}{
 					"1": {
 						image:     image1x1,
-						selection: image1x1.Selection(0, 0),
+						selection: image1x1.Selection(0, 0).WithSize(0, 1),
 						line:      0,
 						expected:  []image.Color{color1},
 					},
 					"2": {
-						image:     image1x1,
-						selection: image1x1.Selection(0, 1),
-						line:      -1,
-						expected:  []image.Color{color1},
+						image:     image1x2,
+						selection: image1x2.Selection(0, 0).WithSize(0, 2),
+						line:      1,
+						expected:  []image.Color{color2},
 					},
 					"3": {
 						image:     image1x2,
-						selection: image1x2.Selection(0, 0),
-						line:      1,
+						selection: image1x2.Selection(0, 1).WithSize(0, 1),
+						line:      0,
 						expected:  []image.Color{color2},
 					},
 					"4": {
 						image:     image1x2,
-						selection: image1x2.Selection(0, 1),
-						line:      0,
-						expected:  []image.Color{color2},
-					},
-					"5": {
-						image:     image1x2,
-						selection: image1x2.Selection(0, 0),
+						selection: image1x2.Selection(0, 0).WithSize(0, 2),
 						line:      0,
 						expected:  []image.Color{color1},
 					},

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -175,6 +175,7 @@ func (f *screenMock) Draw() {
 }
 
 func (f *screenMock) SwapImages() {
+	f.currentImage.Upload()
 	f.visibleImage = f.currentImage
 	newCurrentImage := image.New(f.width, f.height, &acceleratedImageStub{})
 	f.currentImage = newCurrentImage

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -24,8 +24,9 @@ func (t *Tool) SetColor(color image.Color) {
 
 // Clear clears selection with previously set color
 func (t *Tool) Clear(selection image.Selection) {
-	for y := 0; y < selection.Height(); y++ {
-		line, _ := selection.LineForWrite(y)
+	lines := selection.Lines()
+	for y := 0; y < lines.Length(); y++ {
+		line := lines.LineForWrite(y)
 		for x := 0; x < len(line); x++ {
 			line[x] = t.color
 		}

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -25,7 +25,7 @@ func (t *Tool) SetColor(color image.Color) {
 // Clear clears selection with previously set color
 func (t *Tool) Clear(selection image.Selection) {
 	for y := 0; y < selection.Height(); y++ {
-		line := selection.LineForWrite(y)
+		line, _ := selection.LineForWrite(y)
 		for x := 0; x < len(line); x++ {
 			line[x] = t.color
 		}

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -24,10 +24,11 @@ func (t *Tool) SetColor(color image.Color) {
 
 // Clear clears selection with previously set color
 func (t *Tool) Clear(selection image.Selection) {
+	color := t.color
 	for y := 0; y < selection.Height(); y++ {
 		line := selection.Line(y)
 		for x := 0; x < line.Width(); x++ {
-			line.SetColor(x, t.color)
+			line.SetColor(x, color)
 		}
 	}
 }

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -24,11 +24,10 @@ func (t *Tool) SetColor(color image.Color) {
 
 // Clear clears selection with previously set color
 func (t *Tool) Clear(selection image.Selection) {
-	color := t.color
 	for y := 0; y < selection.Height(); y++ {
-		line := selection.Line(y)
-		for x := 0; x < line.Width(); x++ {
-			line.SetColor(x, color)
+		line := selection.LineForWrite(y)
+		for x := 0; x < len(line); x++ {
+			line[x] = t.color
 		}
 	}
 }

--- a/tools/clear/clear.go
+++ b/tools/clear/clear.go
@@ -25,8 +25,9 @@ func (t *Tool) SetColor(color image.Color) {
 // Clear clears selection with previously set color
 func (t *Tool) Clear(selection image.Selection) {
 	for y := 0; y < selection.Height(); y++ {
-		for x := 0; x < selection.Width(); x++ {
-			selection.SetColor(x, y, t.color)
+		line := selection.Line(y)
+		for x := 0; x < line.Width(); x++ {
+			line.SetColor(x, t.color)
 		}
 	}
 }

--- a/tools/clear/clear_bench_test.go
+++ b/tools/clear/clear_bench_test.go
@@ -1,0 +1,24 @@
+package clear_test
+
+import (
+	"testing"
+
+	"github.com/jacekolszak/pixiq/image"
+	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/jacekolszak/pixiq/tools/clear"
+)
+
+func BenchmarkTool_Clear(b *testing.B) {
+	var (
+		width     = 1920
+		height    = 1080
+		img       = image.New(width, height, fake.NewAcceleratedImage(width, height))
+		selection = img.WholeImageSelection()
+		tool      = clear.New()
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tool.Clear(selection)
+	}
+}

--- a/tools/clear/clear_test.go
+++ b/tools/clear/clear_test.go
@@ -70,8 +70,8 @@ func TestClear(t *testing.T) {
 
 func assertColors(t *testing.T, img *image.Image, expectedColorLines [2][2]image.Color) {
 	selection := img.WholeImageSelection()
-	assert.Equal(t, expectedColorLines[0][0], selection.Color(0, 0))
-	assert.Equal(t, expectedColorLines[0][1], selection.Color(1, 0))
-	assert.Equal(t, expectedColorLines[1][0], selection.Color(0, 1))
-	assert.Equal(t, expectedColorLines[1][1], selection.Color(1, 1))
+	assert.Equal(t, expectedColorLines[0][0], selection.Color(0, 0), "position(0,0)")
+	assert.Equal(t, expectedColorLines[0][1], selection.Color(1, 0), "position(1,0)")
+	assert.Equal(t, expectedColorLines[1][0], selection.Color(0, 1), "position(0,1)")
+	assert.Equal(t, expectedColorLines[1][1], selection.Color(1, 1), "position(1,1)")
 }


### PR DESCRIPTION
It should be much more efficient to set/get pixel colors using lines instead of invoking Color(), SetColor() methods for each pixel. Some part of the existing logic might be only executed when Line is created and not on each call. Also bound checks might be eliminated.