### PR TITLE
gl.Finish() before drawing image in a window

### DIFF
--- a/gl/api.go
+++ b/gl/api.go
@@ -114,6 +114,8 @@ type API interface {
 	GetError() uint32
 	// ReadPixels reads a block of pixels from the frame buffer
 	ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer)
+	// Flush forces execution of GL commands in finite time
+	Flush()
 	// Ptr takes a slice or pointer (to a singular scalar value or the first
 	// element of an array or slice) and returns its GL-compatible address.
 	//

--- a/gl/api.go
+++ b/gl/api.go
@@ -114,8 +114,7 @@ type API interface {
 	GetError() uint32
 	// ReadPixels reads a block of pixels from the frame buffer
 	ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer)
-	// Flush forces execution of GL commands in finite time
-	Flush()
+	// Finish blocks until all GL execution is complete
 	Finish()
 	// Ptr takes a slice or pointer (to a singular scalar value or the first
 	// element of an array or slice) and returns its GL-compatible address.

--- a/gl/api.go
+++ b/gl/api.go
@@ -116,6 +116,7 @@ type API interface {
 	ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer)
 	// Flush forces execution of GL commands in finite time
 	Flush()
+	Finish()
 	// Ptr takes a slice or pointer (to a singular scalar value or the first
 	// element of an array or slice) and returns its GL-compatible address.
 	//

--- a/gl/command.go
+++ b/gl/command.go
@@ -211,6 +211,10 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 	y := int32(img.height - locHeight - loc.Y)
 	w := int32(loc.Width)
 	h := int32(locHeight)
+	if x < 0 {
+		w += x
+		x = 0
+	}
 	if y < 0 {
 		h += y
 		y = 0

--- a/gl/command.go
+++ b/gl/command.go
@@ -207,9 +207,6 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 		return
 	}
 	x := int32(loc.X)
-	if x >= int32(img.width) {
-		return
-	}
 	y := int32(loc.Y)
 	w := int32(loc.Width)
 	h := int32(loc.Height)

--- a/gl/command.go
+++ b/gl/command.go
@@ -199,15 +199,15 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 		panic("output image created in a different OpenGL context than program")
 	}
 
-	c.program.use()
-	c.api.Enable(scissorTest)
-	c.api.BindFramebuffer(framebuffer, img.frameBufferID)
 	loc := output.Location
 	locHeight := loc.Height
 	if locHeight > img.height {
 		locHeight = img.height
 	}
 	x := int32(loc.X)
+	if x >= int32(img.width) {
+		return
+	}
 	y := int32(img.height - locHeight - loc.Y)
 	w := int32(loc.Width)
 	h := int32(locHeight)
@@ -215,6 +215,10 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 		h += y
 		y = 0
 	}
+
+	c.program.use()
+	c.api.Enable(scissorTest)
+	c.api.BindFramebuffer(framebuffer, img.frameBufferID)
 	c.api.Scissor(x, y, w, h)
 	c.api.Viewport(x, y, w, h)
 

--- a/gl/command.go
+++ b/gl/command.go
@@ -211,6 +211,10 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 	y := int32(img.height - locHeight - loc.Y)
 	w := int32(loc.Width)
 	h := int32(locHeight)
+	if y < 0 {
+		h += y
+		y = 0
+	}
 	c.api.Scissor(x, y, w, h)
 	c.api.Viewport(x, y, w, h)
 

--- a/gl/command.go
+++ b/gl/command.go
@@ -200,17 +200,19 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 	}
 
 	loc := output.Location
-	locHeight := loc.Height
-	if locHeight > img.height {
-		locHeight = img.height
+	if loc.X >= img.width {
+		return
+	}
+	if loc.Y >= img.height {
+		return
 	}
 	x := int32(loc.X)
 	if x >= int32(img.width) {
 		return
 	}
-	y := int32(img.height - locHeight - loc.Y)
+	y := int32(loc.Y)
 	w := int32(loc.Width)
-	h := int32(locHeight)
+	h := int32(loc.Height)
 	if x < 0 {
 		w += x
 		x = 0
@@ -219,6 +221,7 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 		h += y
 		y = 0
 	}
+	y = int32(img.height) - h - y
 
 	c.program.use()
 	c.api.Enable(scissorTest)

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -536,5 +536,6 @@ func (a apiStub) GetError() uint32 { return 0 }
 func (a apiStub) ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 }
 func (a apiStub) Flush()                              {}
+func (a apiStub) Finish()                             {}
 func (a apiStub) Ptr(data interface{}) unsafe.Pointer { return nil }
 func (a apiStub) PtrOffset(offset int) unsafe.Pointer { return nil }

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -535,5 +535,6 @@ func (a apiStub) GetTexImage(target uint32, level int32, format uint32, xtype ui
 func (a apiStub) GetError() uint32 { return 0 }
 func (a apiStub) ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 }
+func (a apiStub) Flush()                              {}
 func (a apiStub) Ptr(data interface{}) unsafe.Pointer { return nil }
 func (a apiStub) PtrOffset(offset int) unsafe.Pointer { return nil }

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -535,7 +535,6 @@ func (a apiStub) GetTexImage(target uint32, level int32, format uint32, xtype ui
 func (a apiStub) GetError() uint32 { return 0 }
 func (a apiStub) ReadPixels(x int32, y int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 }
-func (a apiStub) Flush()                              {}
 func (a apiStub) Finish()                             {}
 func (a apiStub) Ptr(data interface{}) unsafe.Pointer { return nil }
 func (a apiStub) PtrOffset(offset int) unsafe.Pointer { return nil }

--- a/gl/image.go
+++ b/gl/image.go
@@ -94,7 +94,6 @@ func (i *AcceleratedImage) Upload(pixels []image.Color) {
 		unsignedByte,
 		i.api.Ptr(pixels),
 	)
-	i.api.Finish()
 }
 
 // Download gets pixels pixels from video card

--- a/gl/image.go
+++ b/gl/image.go
@@ -110,5 +110,4 @@ func (i *AcceleratedImage) Download(output []image.Color) {
 		unsignedByte,
 		i.api.Ptr(output),
 	)
-	i.api.Finish()
 }

--- a/gl/image.go
+++ b/gl/image.go
@@ -94,6 +94,7 @@ func (i *AcceleratedImage) Upload(pixels []image.Color) {
 		unsignedByte,
 		i.api.Ptr(pixels),
 	)
+	i.api.Flush()
 }
 
 // Download gets pixels pixels from video card

--- a/gl/image.go
+++ b/gl/image.go
@@ -94,7 +94,7 @@ func (i *AcceleratedImage) Upload(pixels []image.Color) {
 		unsignedByte,
 		i.api.Ptr(pixels),
 	)
-	i.api.Flush()
+	i.api.Finish()
 }
 
 // Download gets pixels pixels from video card

--- a/gl/image.go
+++ b/gl/image.go
@@ -110,4 +110,5 @@ func (i *AcceleratedImage) Download(output []image.Color) {
 		unsignedByte,
 		i.api.Ptr(output),
 	)
+	i.api.Finish()
 }

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -530,10 +530,25 @@ func TestAcceleratedCommand_Run(t *testing.T) {
 					location:       image.AcceleratedImageLocation{X: -1, Width: 2, Height: 1},
 					expectedColors: []image.Color{color},
 				},
-				"y out of bounds": {
+				"y equal image height": {
 					width: 1, height: 1,
 					location:       image.AcceleratedImageLocation{Y: 1, Width: 1, Height: 1},
 					expectedColors: []image.Color{image.Transparent},
+				},
+				"y higher than image height": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{Y: 2, Width: 1, Height: 1},
+					expectedColors: []image.Color{image.Transparent},
+				},
+				"negative y": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{Y: -1, Width: 1, Height: 1},
+					expectedColors: []image.Color{image.Transparent},
+				},
+				"negative y, height 2": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{Y: -1, Width: 1, Height: 2},
+					expectedColors: []image.Color{color},
 				},
 				"whole image": {
 					width: 1, height: 1,

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -510,10 +510,25 @@ func TestAcceleratedCommand_Run(t *testing.T) {
 					location:       image.AcceleratedImageLocation{},
 					expectedColors: []image.Color{image.Transparent},
 				},
-				"x out of bounds": {
+				"x equal image width": {
 					width: 1, height: 1,
 					location:       image.AcceleratedImageLocation{X: 1, Width: 1, Height: 1},
 					expectedColors: []image.Color{image.Transparent},
+				},
+				"x higher than image width": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{X: 2, Width: 1, Height: 1},
+					expectedColors: []image.Color{image.Transparent},
+				},
+				"negative x": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{X: -1, Width: 1, Height: 1},
+					expectedColors: []image.Color{image.Transparent},
+				},
+				"negative x, width 2": {
+					width: 1, height: 1,
+					location:       image.AcceleratedImageLocation{X: -1, Width: 2, Height: 1},
+					expectedColors: []image.Color{color},
 				},
 				"y out of bounds": {
 					width: 1, height: 1,

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -404,6 +404,13 @@ func (g *context) ReadPixels(x int32, y int32, width int32, height int32, format
 	})
 }
 
+// Flush forces execution of GL commands in finite time
+func (g *context) Flush() {
+	g.run(func() {
+		gl.Flush()
+	})
+}
+
 // Ptr takes a slice or pointer (to a singular scalar value or the first
 // element of an array or slice) and returns its GL-compatible address.
 //

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -411,6 +411,12 @@ func (g *context) Flush() {
 	})
 }
 
+func (g *context) Finish() {
+	g.run(func() {
+		gl.Finish()
+	})
+}
+
 // Ptr takes a slice or pointer (to a singular scalar value or the first
 // element of an array or slice) and returns its GL-compatible address.
 //

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -404,13 +404,7 @@ func (g *context) ReadPixels(x int32, y int32, width int32, height int32, format
 	})
 }
 
-// Flush forces execution of GL commands in finite time
-func (g *context) Flush() {
-	g.run(func() {
-		gl.Flush()
-	})
-}
-
+// Finish blocks until all GL execution is complete
 func (g *context) Finish() {
 	g.run(func() {
 		gl.Finish()

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -203,6 +203,7 @@ func (g *OpenGL) OpenWindow(width, height int, options ...WindowOption) (*Window
 		requestedHeight:        height,
 		screenAcceleratedImage: screenAcceleratedImage,
 		screenImage:            screenImage,
+		mainContext:            g.context,
 		zoom:                   1,
 	}
 	var err error

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -197,14 +197,13 @@ func (g *OpenGL) OpenWindow(width, height int, options ...WindowOption) (*Window
 	screenAcceleratedImage := g.context.NewAcceleratedImage(width, height)
 	screenImage := image.New(width, height, screenAcceleratedImage)
 	win := &Window{
-		mainThreadLoop:         g.mainThreadLoop,
-		keyboardEvents:         keyboardEvents,
-		requestedWidth:         width,
-		requestedHeight:        height,
-		screenAcceleratedImage: screenAcceleratedImage,
-		screenImage:            screenImage,
-		mainContext:            g.context,
-		zoom:                   1,
+		mainThreadLoop:   g.mainThreadLoop,
+		keyboardEvents:   keyboardEvents,
+		requestedWidth:   width,
+		requestedHeight:  height,
+		screenImage:      screenImage,
+		screenContextAPI: g.context.API(),
+		zoom:             1,
 	}
 	var err error
 	g.mainThreadLoop.Execute(func() {
@@ -248,7 +247,7 @@ func (g *OpenGL) OpenWindow(width, height int, options ...WindowOption) (*Window
 	}
 	// in this window context there is only one program used with one texture
 	win.api.UseProgram(win.program.ID())
-	win.api.BindTexture(gl33.TEXTURE_2D, win.screenAcceleratedImage.TextureID())
+	win.api.BindTexture(gl33.TEXTURE_2D, screenAcceleratedImage.TextureID())
 	return win, nil
 }
 

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -29,7 +29,6 @@ type Window struct {
 // after SwapImages is called.
 func (w *Window) Draw() {
 	w.screenImage.Upload()
-	w.ContextAPI().Flush()
 	var width, height int
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -23,12 +23,14 @@ type Window struct {
 	api                    gl.API
 	context                *gl.Context
 	program                *gl.Program
+	mainContext            *gl.Context
 }
 
 // Draw draws a screen image to the invisible buffer. It will be shown in window
 // after SwapImages is called.
 func (w *Window) Draw() {
 	w.screenImage.Upload()
+	w.mainContext.API().Finish()
 	var width, height int
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -29,6 +29,7 @@ type Window struct {
 // after SwapImages is called.
 func (w *Window) Draw() {
 	w.screenImage.Upload()
+	w.ContextAPI().Flush()
 	var width, height int
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -11,26 +11,25 @@ import (
 
 // Window is an implementation of loop.Screen and keyboard.EventSource
 type Window struct {
-	glfwWindow             *glfw.Window
-	mainThreadLoop         *MainThreadLoop
-	screenPolygon          *screenPolygon
-	keyboardEvents         *internal.KeyboardEvents
-	requestedWidth         int
-	requestedHeight        int
-	zoom                   int
-	screenImage            *image.Image
-	screenAcceleratedImage *gl.AcceleratedImage
-	api                    gl.API
-	context                *gl.Context
-	program                *gl.Program
-	mainContext            *gl.Context
+	glfwWindow       *glfw.Window
+	mainThreadLoop   *MainThreadLoop
+	screenPolygon    *screenPolygon
+	keyboardEvents   *internal.KeyboardEvents
+	requestedWidth   int
+	requestedHeight  int
+	zoom             int
+	screenImage      *image.Image
+	screenContextAPI gl.API
+	api              gl.API
+	context          *gl.Context
+	program          *gl.Program
 }
 
 // Draw draws a screen image to the invisible buffer. It will be shown in window
 // after SwapImages is called.
 func (w *Window) Draw() {
 	w.screenImage.Upload()
-	w.mainContext.API().Finish()
+	w.screenContextAPI.Finish()
 	var width, height int
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()


### PR DESCRIPTION
Because two different contexts (main and window context) share textures we need to tell the main context to finish all pending operations before the resulted texture can be sampled by a window context.  