### PR TITLE
Simplify Screen interface

### DIFF
--- a/glfw/window.go
+++ b/glfw/window.go
@@ -25,7 +25,8 @@ type Window struct {
 	program          *gl.Program
 }
 
-// Draw draws a screen image in the window
+// Draw draws a screen image to the invisible buffer. It will be shown in window
+// after SwapImages is called.
 func (w *Window) Draw() {
 	w.screenImage.Upload()
 	w.screenContextAPI.Finish()
@@ -35,6 +36,10 @@ func (w *Window) Draw() {
 	})
 	w.api.Viewport(0, 0, int32(width), int32(height))
 	w.screenPolygon.draw()
+}
+
+// SwapImages makes last drawn image visible in window.
+func (w *Window) SwapImages() {
 	w.mainThreadLoop.Execute(w.glfwWindow.SwapBuffers)
 }
 

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -27,6 +27,13 @@ type Window struct {
 
 // Draw draws a screen image in the window
 func (w *Window) Draw() {
+	w.DrawIntoBackBuffer()
+	w.SwapBuffers()
+}
+
+// DrawIntoBackBuffer draws a screen image into the back buffer. To make it visible
+// to the user SwapBuffers must be executed.
+func (w *Window) DrawIntoBackBuffer() {
 	w.screenImage.Upload()
 	w.screenContextAPI.Finish()
 	var width, height int
@@ -35,6 +42,10 @@ func (w *Window) Draw() {
 	})
 	w.api.Viewport(0, 0, int32(width), int32(height))
 	w.screenPolygon.draw()
+}
+
+// SwapBuffers makes current back buffer visible to the user.
+func (w *Window) SwapBuffers() {
 	w.mainThreadLoop.Execute(w.glfwWindow.SwapBuffers)
 }
 

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -25,8 +25,7 @@ type Window struct {
 	program          *gl.Program
 }
 
-// Draw draws a screen image to the invisible buffer. It will be shown in window
-// after SwapImages is called.
+// Draw draws a screen image in the window
 func (w *Window) Draw() {
 	w.screenImage.Upload()
 	w.screenContextAPI.Finish()
@@ -36,10 +35,6 @@ func (w *Window) Draw() {
 	})
 	w.api.Viewport(0, 0, int32(width), int32(height))
 	w.screenPolygon.draw()
-}
-
-// SwapImages makes last drawn image visible in window.
-func (w *Window) SwapImages() {
 	w.mainThreadLoop.Execute(w.glfwWindow.SwapBuffers)
 }
 

--- a/glfw/window_test.go
+++ b/glfw/window_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jacekolszak/pixiq/keyboard"
 )
 
-func TestWindow_Draw(t *testing.T) {
+func TestWindow_DrawIntoBackBuffer(t *testing.T) {
 	t.Run("should draw screen image", func(t *testing.T) {
 		color1 := image.RGBA(10, 20, 30, 40)
 		color2 := image.RGBA(50, 60, 70, 80)
@@ -30,7 +30,7 @@ func TestWindow_Draw(t *testing.T) {
 			defer window.Close()
 			window.Image().WholeImageSelection().SetColor(0, 0, color1)
 			// when
-			window.Draw()
+			window.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color1}
 			assert.Equal(t, expected, framebufferPixels(window.ContextAPI(), 0, 0, 1, 1))
@@ -46,7 +46,7 @@ func TestWindow_Draw(t *testing.T) {
 			img.WholeImageSelection().SetColor(0, 0, color1)
 			img.WholeImageSelection().SetColor(0, 1, color2)
 			// when
-			window.Draw()
+			window.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color2, color1}
 			assert.Equal(t, expected, framebufferPixels(window.ContextAPI(), 0, 0, 1, 2))
@@ -62,7 +62,7 @@ func TestWindow_Draw(t *testing.T) {
 			img.WholeImageSelection().SetColor(0, 0, color1)
 			img.WholeImageSelection().SetColor(1, 0, color2)
 			// when
-			window.Draw()
+			window.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color1, color2}
 			assert.Equal(t, expected, framebufferPixels(window.ContextAPI(), 0, 0, 2, 1))
@@ -81,7 +81,7 @@ func TestWindow_Draw(t *testing.T) {
 			selection.SetColor(0, 1, color3)
 			selection.SetColor(1, 1, color4)
 			// when
-			window.Draw()
+			window.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color3, color4, color1, color2}
 			assert.Equal(t, expected, framebufferPixels(window.ContextAPI(), 0, 0, 2, 2))
@@ -100,7 +100,7 @@ func TestWindow_Draw(t *testing.T) {
 					img := window.Image()
 					img.WholeImageSelection().SetColor(0, 0, color1)
 					// when
-					window.Draw()
+					window.DrawIntoBackBuffer()
 					// then
 					expected := []image.Color{color1}
 					assert.Equal(t, expected, framebufferPixels(window.ContextAPI(), 0, 0, 1, 1))
@@ -121,7 +121,7 @@ func TestWindow_Draw(t *testing.T) {
 					img := window.Image()
 					img.WholeImageSelection().SetColor(0, 0, color1)
 					// when
-					window.Draw()
+					window.DrawIntoBackBuffer()
 					// then
 					expected := make([]image.Color, zoom*zoom)
 					for i := 0; i < len(expected); i++ {
@@ -143,12 +143,12 @@ func TestWindow_Draw(t *testing.T) {
 			require.NoError(t, err)
 			defer window2.Close()
 			// when
-			window1.Draw()
+			window1.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color1}
 			assert.Equal(t, expected, framebufferPixels(window1.ContextAPI(), 0, 0, 1, 1))
 			// when
-			window2.Draw()
+			window2.DrawIntoBackBuffer()
 			// then
 			expected = []image.Color{color2}
 			assert.Equal(t, expected, framebufferPixels(window2.ContextAPI(), 0, 0, 1, 1))
@@ -168,12 +168,12 @@ func TestWindow_Draw(t *testing.T) {
 			require.NoError(t, err)
 			defer window2.Close()
 			// when
-			window1.Draw()
+			window1.DrawIntoBackBuffer()
 			// then
 			expected := []image.Color{color1}
 			assert.Equal(t, expected, framebufferPixels(window1.ContextAPI(), 0, 0, 1, 1))
 			// when
-			window2.Draw()
+			window2.DrawIntoBackBuffer()
 			// then
 			expected = []image.Color{color2}
 			assert.Equal(t, expected, framebufferPixels(window2.ContextAPI(), 0, 0, 1, 1))

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -8,7 +8,11 @@ type Screen interface {
 	// Returns the image spanning the whole screen.
 	Image() *image.Image
 	// Draw draws the image on the screen.
+	// If double buffering is used it may draw to the invisible buffer.
 	Draw()
+	// SwapImages makes last drawn image visible (if double buffering was used,
+	// otherwise it may be a no-op)
+	SwapImages()
 }
 
 // Run starts the screen loop. It will execute onEachFrame function for each frame,
@@ -19,6 +23,7 @@ func Run(screen Screen, onEachFrame func(frame *Frame)) {
 		frame.screen = screen.Image().WholeImageSelection()
 		onEachFrame(frame)
 		screen.Draw()
+		screen.SwapImages()
 	}
 }
 

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -8,11 +8,7 @@ type Screen interface {
 	// Returns the image spanning the whole screen.
 	Image() *image.Image
 	// Draw draws the image on the screen.
-	// If double buffering is used it may draw to the invisible buffer.
 	Draw()
-	// SwapImages makes last drawn image visible (if double buffering was used,
-	// otherwise it may be a no-op)
-	SwapImages()
 }
 
 // Run starts the screen loop. It will execute onEachFrame function for each frame,
@@ -23,7 +19,6 @@ func Run(screen Screen, onEachFrame func(frame *Frame)) {
 		frame.screen = screen.Image().WholeImageSelection()
 		onEachFrame(frame)
 		screen.Draw()
-		screen.SwapImages()
 	}
 }
 

--- a/loop/loop_bench_test.go
+++ b/loop/loop_bench_test.go
@@ -34,3 +34,6 @@ func (d *noopScreen) Image() *image.Image {
 
 func (d *noopScreen) Draw() {
 }
+
+func (d *noopScreen) SwapImages() {
+}

--- a/loop/loop_bench_test.go
+++ b/loop/loop_bench_test.go
@@ -34,6 +34,3 @@ func (d *noopScreen) Image() *image.Image {
 
 func (d *noopScreen) Draw() {
 }
-
-func (d *noopScreen) SwapImages() {
-}

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -62,9 +62,8 @@ func TestRun(t *testing.T) {
 
 	t.Run("should draw image for each frame", func(t *testing.T) {
 		var (
-			screen         = newScreenMock(1, 1)
-			firstFrame     = true
-			recordedImages []*image.Image
+			screen     = newScreenMock(1, 1)
+			firstFrame = true
 		)
 		// when
 		loop.Run(screen, func(frame *loop.Frame) {
@@ -72,10 +71,11 @@ func TestRun(t *testing.T) {
 				frame.StopLoopEventually()
 			}
 			firstFrame = false
-			recordedImages = append(recordedImages, frame.Screen().Image())
 		})
 		// then
-		assert.Equal(t, recordedImages, screen.imagesDrawn)
+		require.Len(t, screen.imagesDrawn, 2)
+		assert.Equal(t, image.Transparent, screen.imagesDrawn[0].WholeImageSelection().Color(0, 0))
+		assert.Equal(t, image.Transparent, screen.imagesDrawn[1].WholeImageSelection().Color(0, 0))
 	})
 
 	t.Run("should draw modified screen", func(t *testing.T) {
@@ -175,7 +175,6 @@ func (f *screenMock) Draw() {
 }
 
 func (f *screenMock) SwapImages() {
-	f.currentImage.Upload()
 	f.visibleImage = f.currentImage
 	newCurrentImage := image.New(f.width, f.height, &acceleratedImageStub{})
 	f.currentImage = newCurrentImage

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -117,35 +117,6 @@ func TestRun(t *testing.T) {
 		})
 	})
 
-	t.Run("should swap images", func(t *testing.T) {
-		t.Run("after first frame", func(t *testing.T) {
-			screen := newScreenMock(1, 1)
-			// when
-			loop.Run(screen, func(frame *loop.Frame) {
-				frame.StopLoopEventually()
-			})
-			// then
-			require.Len(t, screen.imagesDrawn, 1)
-			assert.Same(t, screen.imagesDrawn[0], screen.visibleImage)
-		})
-		t.Run("after second frame", func(t *testing.T) {
-			var (
-				screen     = newScreenMock(1, 1)
-				firstFrame = true
-			)
-			// when
-			loop.Run(screen, func(frame *loop.Frame) {
-				if !firstFrame {
-					frame.StopLoopEventually()
-				}
-				firstFrame = false
-			})
-			// then
-			require.Len(t, screen.imagesDrawn, 2)
-			assert.Same(t, screen.imagesDrawn[1], screen.visibleImage)
-		})
-	})
-
 }
 
 type screenMock struct {
@@ -153,7 +124,6 @@ type screenMock struct {
 	imagesDrawn  []*image.Image
 	width        int
 	height       int
-	visibleImage *image.Image
 }
 
 func newScreenMock(width, height int) *screenMock {
@@ -172,12 +142,6 @@ func (f *screenMock) Image() *image.Image {
 func (f *screenMock) Draw() {
 	f.currentImage = clone(f.currentImage)
 	f.imagesDrawn = append(f.imagesDrawn, f.currentImage)
-}
-
-func (f *screenMock) SwapImages() {
-	f.visibleImage = f.currentImage
-	newCurrentImage := image.New(f.width, f.height, &acceleratedImageStub{})
-	f.currentImage = newCurrentImage
 }
 
 func clone(original *image.Image) *image.Image {

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -117,6 +117,35 @@ func TestRun(t *testing.T) {
 		})
 	})
 
+	t.Run("should swap images", func(t *testing.T) {
+		t.Run("after first frame", func(t *testing.T) {
+			screen := newScreenMock(1, 1)
+			// when
+			loop.Run(screen, func(frame *loop.Frame) {
+				frame.StopLoopEventually()
+			})
+			// then
+			require.Len(t, screen.imagesDrawn, 1)
+			assert.Same(t, screen.imagesDrawn[0], screen.visibleImage)
+		})
+		t.Run("after second frame", func(t *testing.T) {
+			var (
+				screen     = newScreenMock(1, 1)
+				firstFrame = true
+			)
+			// when
+			loop.Run(screen, func(frame *loop.Frame) {
+				if !firstFrame {
+					frame.StopLoopEventually()
+				}
+				firstFrame = false
+			})
+			// then
+			require.Len(t, screen.imagesDrawn, 2)
+			assert.Same(t, screen.imagesDrawn[1], screen.visibleImage)
+		})
+	})
+
 }
 
 type screenMock struct {
@@ -124,6 +153,7 @@ type screenMock struct {
 	imagesDrawn  []*image.Image
 	width        int
 	height       int
+	visibleImage *image.Image
 }
 
 func newScreenMock(width, height int) *screenMock {
@@ -142,6 +172,12 @@ func (f *screenMock) Image() *image.Image {
 func (f *screenMock) Draw() {
 	f.currentImage = clone(f.currentImage)
 	f.imagesDrawn = append(f.imagesDrawn, f.currentImage)
+}
+
+func (f *screenMock) SwapImages() {
+	f.visibleImage = f.currentImage
+	newCurrentImage := image.New(f.width, f.height, &acceleratedImageStub{})
+	f.currentImage = newCurrentImage
 }
 
 func clone(original *image.Image) *image.Image {


### PR DESCRIPTION
Screen#SwapImages method is redundant. Loop does not have to know if double buffering is used at all. We can safely remove this method, which will greatly simplify the loop package.