### PR TITLE
Decrease CPU usage for a single window games

### DIFF
--- a/examples/blend/main.go
+++ b/examples/blend/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	glfw.RunOrDie(func(gl *glfw.OpenGL) {
-		window, err := gl.OpenWindow(37, 40, glfw.Zoom(10))
+		window, err := gl.OpenWindow(37, 40, glfw.Zoom(10), glfw.Title("Blend window"))
 		if err != nil {
 			panic(err)
 		}

--- a/gl/api.go
+++ b/gl/api.go
@@ -108,6 +108,8 @@ type API interface {
 	TexParameteri(target uint32, pname uint32, param int32)
 	// GenFramebuffers generates framebuffer object names
 	GenFramebuffers(n int32, framebuffers *uint32)
+	// DeleteFramebuffers deletes named framebuffer objects
+	DeleteFramebuffers(n int32, framebuffers *uint32)
 	// FramebufferTexture2D attaches a level of a texture object as a logical buffer to the currently bound framebuffer object
 	FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32)
 	// TexSubImage2D specifies a two-dimensional texture subimage

--- a/gl/api.go
+++ b/gl/api.go
@@ -50,6 +50,8 @@ type API interface {
 	UseProgram(program uint32)
 	// CreateProgram creates a program object
 	CreateProgram() uint32
+	// DeleteProgram deletes a program object
+	DeleteProgram(program uint32)
 	// GetActiveUniform returns information about an active uniform variable for the specified program object
 	GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8)
 	// GetActiveAttrib returns information about an active attribute variable for the specified program object
@@ -98,6 +100,8 @@ type API interface {
 	GetIntegerv(pname uint32, data *int32)
 	// GenTextures generates texture names
 	GenTextures(n int32, textures *uint32)
+	// DeleteTextures deletes named textures
+	DeleteTextures(n int32, textures *uint32)
 	// TexImage2D specifies a two-dimensional texture image
 	TexImage2D(target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer)
 	// TexParameteri sets texture parameter

--- a/gl/api.go
+++ b/gl/api.go
@@ -58,8 +58,10 @@ type API interface {
 	GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8)
 	// GetAttribLocation returns the location of an attribute variable
 	GetAttribLocation(program uint32, name *uint8) int32
-	// Enable enables or disable server-side GL capabilities
+	// Enable enables server-side GL capabilities
 	Enable(cap uint32)
+	// Disable disables server-side GL capabilities
+	Disable(cap uint32)
 	// BindFramebuffer binds a framebuffer to a framebuffer target
 	BindFramebuffer(target uint32, framebuffer uint32)
 	// Scissor defines the scissor box

--- a/gl/command.go
+++ b/gl/command.go
@@ -241,7 +241,7 @@ func (c *AcceleratedCommand) Run(output image.AcceleratedImageSelection, selecti
 	}
 	img, ok := c.allImages[output.Image]
 	if !ok {
-		panic("output image created in a different OpenGL context than program")
+		panic("output image created in a different OpenGL context than program or deleted")
 	}
 
 	loc := output.Location

--- a/gl/context.go
+++ b/gl/context.go
@@ -134,13 +134,18 @@ func (c *Context) CompileFragmentShader(sourceCode string) (*FragmentShader, err
 	if err != nil {
 		return nil, err
 	}
-	return &FragmentShader{id: shaderID}, nil
+	return &FragmentShader{id: shaderID, api: c.api}, nil
 }
 
 // FragmentShader is a part of an OpenGL program which transforms each fragment
 // (pixel) color into another one
 type FragmentShader struct {
-	id uint32
+	id  uint32
+	api API
+}
+
+func (s *FragmentShader) Delete() {
+	s.api.DeleteShader(s.id)
 }
 
 // CompileVertexShader compiles vertex shader source code written in GLSL.
@@ -149,13 +154,18 @@ func (c *Context) CompileVertexShader(sourceCode string) (*VertexShader, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &VertexShader{id: shaderID}, nil
+	return &VertexShader{id: shaderID, api: c.api}, nil
 }
 
 // VertexShader is a part of an OpenGL program which applies transformations
 // to drawn vertices.
 type VertexShader struct {
-	id uint32
+	id  uint32
+	api API
+}
+
+func (s *VertexShader) Delete() {
+	s.api.DeleteShader(s.id)
 }
 
 func (c *Context) compileShader(xtype uint32, src string) (uint32, error) {
@@ -306,6 +316,10 @@ func (p *Program) use() {
 	if p.program != nil {
 		p.api.UseProgram(p.id)
 	}
+}
+
+func (p *Program) Delete() {
+	p.api.DeleteShader(p.id)
 }
 
 // NewClearCommand returns a command clearing all pixels in image.Selection

--- a/gl/context.go
+++ b/gl/context.go
@@ -319,7 +319,7 @@ func (p *Program) use() {
 }
 
 func (p *Program) Delete() {
-	p.api.DeleteShader(p.id)
+	p.api.DeleteProgram(p.id)
 }
 
 // NewClearCommand returns a command clearing all pixels in image.Selection

--- a/gl/context.go
+++ b/gl/context.go
@@ -144,6 +144,7 @@ type FragmentShader struct {
 	api API
 }
 
+// Delete deletes the shader in the OpenGL driver
 func (s *FragmentShader) Delete() {
 	s.api.DeleteShader(s.id)
 }
@@ -164,6 +165,7 @@ type VertexShader struct {
 	api API
 }
 
+// Delete deletes the shader in the OpenGL driver
 func (s *VertexShader) Delete() {
 	s.api.DeleteShader(s.id)
 }
@@ -318,6 +320,7 @@ func (p *Program) use() {
 	}
 }
 
+// Delete deletes the program in the OpenGL driver
 func (p *Program) Delete() {
 	p.api.DeleteProgram(p.id)
 }

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -540,6 +540,7 @@ func (a apiStub) TexImage2D(target uint32, level int32, internalformat int32, wi
 }
 func (a apiStub) TexParameteri(target uint32, pname uint32, param int32) {}
 func (a apiStub) GenFramebuffers(n int32, framebuffers *uint32)          {}
+func (a apiStub) DeleteFramebuffers(n int32, framebuffers *uint32)       {}
 func (a apiStub) FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 }
 func (a apiStub) TexSubImage2D(target uint32, level int32, xoffset int32, yoffset int32, width int32, height int32, format uint32, xtype uint32, pixels unsafe.Pointer) {

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -534,7 +534,8 @@ func (a apiStub) GetIntegerv(pname uint32, data *int32) {
 		*data = 1024 * 1024
 	}
 }
-func (a apiStub) GenTextures(n int32, textures *uint32) {}
+func (a apiStub) GenTextures(n int32, textures *uint32)    {}
+func (a apiStub) DeleteTextures(n int32, textures *uint32) {}
 func (a apiStub) TexImage2D(target uint32, level int32, internalformat int32, width int32, height int32, border int32, format uint32, xtype uint32, pixels unsafe.Pointer) {
 }
 func (a apiStub) TexParameteri(target uint32, pname uint32, param int32) {}

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -503,6 +503,7 @@ func (a apiStub) GetProgramiv(program uint32, pname uint32, params *int32) {
 func (a apiStub) GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {}
 func (a apiStub) UseProgram(program uint32)                                                      {}
 func (a apiStub) CreateProgram() uint32                                                          { return 0 }
+func (a apiStub) DeleteProgram(program uint32)                                                   {}
 func (a apiStub) GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 }
 func (a apiStub) GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -510,6 +510,7 @@ func (a apiStub) GetActiveAttrib(program uint32, index uint32, bufSize int32, le
 }
 func (a apiStub) GetAttribLocation(program uint32, name *uint8) int32                          { return 0 }
 func (a apiStub) Enable(cap uint32)                                                            {}
+func (a apiStub) Disable(cap uint32)                                                           {}
 func (a apiStub) BindFramebuffer(target uint32, framebuffer uint32)                            {}
 func (a apiStub) Scissor(x int32, y int32, width int32, height int32)                          {}
 func (a apiStub) Viewport(x int32, y int32, width int32, height int32)                         {}

--- a/gl/image.go
+++ b/gl/image.go
@@ -122,3 +122,11 @@ func (i *AcceleratedImage) Width() int {
 func (i *AcceleratedImage) Height() int {
 	return i.height
 }
+
+// Delete cleans resources, usually pixels stored in external memory (such as VRAM).
+// After AcceleratedImage is deleted it cannot be used anymore. Subsequent calls
+// will generate OpenGL error which can be returned by executing Context.Error()
+func (i *AcceleratedImage) Delete() {
+	i.api.DeleteTextures(1, &i.textureID)
+	i.api.DeleteBuffers(1, &i.frameBufferID)
+}

--- a/gl/image.go
+++ b/gl/image.go
@@ -128,5 +128,6 @@ func (i *AcceleratedImage) Height() int {
 // will generate OpenGL error which can be returned by executing Context.Error()
 func (i *AcceleratedImage) Delete() {
 	i.api.DeleteTextures(1, &i.textureID)
-	i.api.DeleteBuffers(1, &i.frameBufferID)
+	i.api.DeleteFramebuffers(1, &i.frameBufferID)
+	// TODO Remove from allimages
 }

--- a/gl/image.go
+++ b/gl/image.go
@@ -53,6 +53,9 @@ func (c *Context) NewAcceleratedImage(width, height int) *AcceleratedImage {
 		api:           c.api,
 	}
 	c.allImages[img] = img
+	img.onDelete = func() {
+		delete(c.allImages, img)
+	}
 	clearWithTransparentColor := c.NewClearCommand()
 	clearWithTransparentColor.Run(img.wholeSelection(), []image.AcceleratedImageSelection{})
 	return img
@@ -65,6 +68,7 @@ type AcceleratedImage struct {
 	frameBufferID uint32
 	width, height int
 	api           API
+	onDelete      func()
 }
 
 func (i *AcceleratedImage) wholeSelection() image.AcceleratedImageSelection {
@@ -129,5 +133,5 @@ func (i *AcceleratedImage) Height() int {
 func (i *AcceleratedImage) Delete() {
 	i.api.DeleteTextures(1, &i.textureID)
 	i.api.DeleteFramebuffers(1, &i.frameBufferID)
-	// TODO Remove from allimages
+	i.onDelete()
 }

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -467,6 +467,27 @@ func TestAcceleratedImage_Upload(t *testing.T) {
 	})
 }
 
+func TestAcceleratedImage_Delete(t *testing.T) {
+	t.Run("should delete resources", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		context := openGL.Context()
+		img := context.NewAcceleratedImage(1, 1)
+		color := image.RGBA(10, 20, 30, 40)
+		img.Upload([]image.Color{color})
+		// when
+		img.Delete()
+		// then
+		err := context.Error()
+		require.NoError(t, err)
+		// and
+		output := make([]image.Color, 1)
+		img.Download(output)
+		err = context.Error()
+		require.Error(t, err)
+	})
+}
+
 func TestAcceleratedCommand_Run(t *testing.T) {
 	t.Run("vertex buffer can be used inside command", func(t *testing.T) {
 		openGL, _ := glfw.NewOpenGL(mainThreadLoop)

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -468,10 +468,10 @@ func TestAcceleratedImage_Upload(t *testing.T) {
 }
 
 func TestAcceleratedImage_Delete(t *testing.T) {
+	openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+	defer openGL.Destroy()
+	ctx := openGL.Context()
 	t.Run("Delete should not return error", func(t *testing.T) {
-		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
-		defer openGL.Destroy()
-		ctx := openGL.Context()
 		img := ctx.NewAcceleratedImage(1, 1)
 		color := image.RGBA(10, 20, 30, 40)
 		img.Upload([]image.Color{color})
@@ -482,9 +482,6 @@ func TestAcceleratedImage_Delete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("trying to download deleted image generates gl error", func(t *testing.T) {
-		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
-		defer openGL.Destroy()
-		ctx := openGL.Context()
 		img := ctx.NewAcceleratedImage(1, 1)
 		color := image.RGBA(10, 20, 30, 40)
 		img.Upload([]image.Color{color})
@@ -497,9 +494,6 @@ func TestAcceleratedImage_Delete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("Command using deleted image panics", func(t *testing.T) {
-		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
-		defer openGL.Destroy()
-		ctx := openGL.Context()
 		img := ctx.NewAcceleratedImage(1, 1)
 		color := image.RGBA(10, 20, 30, 40)
 		img.Upload([]image.Color{color})

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -468,23 +468,56 @@ func TestAcceleratedImage_Upload(t *testing.T) {
 }
 
 func TestAcceleratedImage_Delete(t *testing.T) {
-	t.Run("should delete resources", func(t *testing.T) {
+	t.Run("Delete should not return error", func(t *testing.T) {
 		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
 		defer openGL.Destroy()
-		context := openGL.Context()
-		img := context.NewAcceleratedImage(1, 1)
+		ctx := openGL.Context()
+		img := ctx.NewAcceleratedImage(1, 1)
 		color := image.RGBA(10, 20, 30, 40)
 		img.Upload([]image.Color{color})
 		// when
 		img.Delete()
 		// then
-		err := context.Error()
-		require.NoError(t, err)
-		// and
+		err := ctx.Error()
+		assert.NoError(t, err)
+	})
+	t.Run("trying to download deleted image generates gl error", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		ctx := openGL.Context()
+		img := ctx.NewAcceleratedImage(1, 1)
+		color := image.RGBA(10, 20, 30, 40)
+		img.Upload([]image.Color{color})
+		img.Delete()
 		output := make([]image.Color, 1)
+		// when
 		img.Download(output)
-		err = context.Error()
-		require.Error(t, err)
+		// then
+		err := ctx.Error()
+		assert.Error(t, err)
+	})
+	t.Run("Command using deleted image panics", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		ctx := openGL.Context()
+		img := ctx.NewAcceleratedImage(1, 1)
+		color := image.RGBA(10, 20, 30, 40)
+		img.Upload([]image.Color{color})
+		img.Delete()
+		program := workingProgram(t, ctx)
+		cmd := program.AcceleratedCommand(&emptyCommand{})
+		assert.Panics(t, func() {
+			// when
+			cmd.Run(image.AcceleratedImageSelection{
+				Location: image.AcceleratedImageLocation{
+					X:      0,
+					Y:      0,
+					Width:  1,
+					Height: 1,
+				},
+				Image: img,
+			}, []image.AcceleratedImageSelection{})
+		})
 	})
 }
 

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -194,6 +194,13 @@ func (g *context) CreateProgram() uint32 {
 	return program
 }
 
+// DeleteProgram deletes a program object
+func (g *context) DeleteProgram(program uint32) {
+	g.run(func() {
+		gl.DeleteProgram(program)
+	})
+}
+
 // GetActiveUniform returns information about an active uniform variable for the specified program object
 func (g *context) GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	g.run(func() {
@@ -361,6 +368,12 @@ func (g *context) GetIntegerv(pname uint32, data *int32) {
 func (g *context) GenTextures(n int32, textures *uint32) {
 	g.run(func() {
 		gl.GenTextures(n, textures)
+	})
+}
+
+func (g *context) DeleteTextures(n int32, textures *uint32) {
+	g.run(func() {
+		gl.DeleteTextures(n, textures)
 	})
 }
 

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -1,6 +1,7 @@
 package glfw
 
 import (
+	"github.com/go-gl/glfw/v3.3/glfw"
 	"unsafe"
 
 	"github.com/go-gl/gl/v3.3-core/gl"
@@ -9,6 +10,23 @@ import (
 type context struct {
 	run      func(func())
 	runAsync func(func())
+}
+
+func newContext(mainThreadLoop *MainThreadLoop, window *glfw.Window) *context {
+	return &context{
+		run: func(f func()) {
+			mainThreadLoop.executeCommand(command{
+				window:  window,
+				execute: f,
+			})
+		},
+		runAsync: func(f func()) {
+			mainThreadLoop.executeAsyncCommand(command{
+				window:  window,
+				execute: f,
+			})
+		},
+	}
 }
 
 // GenBuffers generates buffer object names

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -231,6 +231,13 @@ func (g *context) Enable(cap uint32) {
 	})
 }
 
+// Disable disables server-side GL capabilities
+func (g *context) Disable(cap uint32) {
+	g.runAsync(func() {
+		gl.Disable(cap)
+	})
+}
+
 // BindFramebuffer binds a framebuffer to a framebuffer target
 func (g *context) BindFramebuffer(target uint32, framebuffer uint32) {
 	g.runAsync(func() {

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -398,6 +398,13 @@ func (g *context) GenFramebuffers(n int32, framebuffers *uint32) {
 	})
 }
 
+// DeleteFramebuffers generates framebuffer object names
+func (g *context) DeleteFramebuffers(n int32, framebuffers *uint32) {
+	g.run(func() {
+		gl.DeleteFramebuffers(n, framebuffers)
+	})
+}
+
 // FramebufferTexture2D attaches a level of a texture object as a logical buffer to the currently bound framebuffer object
 func (g *context) FramebufferTexture2D(target uint32, attachment uint32, textarget uint32, texture uint32, level int32) {
 	g.runAsync(func() {

--- a/glfw/gl_api.go
+++ b/glfw/gl_api.go
@@ -1,10 +1,10 @@
 package glfw
 
 import (
-	"github.com/go-gl/glfw/v3.3/glfw"
 	"unsafe"
 
 	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
 type context struct {

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -6,7 +6,6 @@
 package glfw
 
 import (
-	"log"
 	"sync"
 	"time"
 
@@ -14,11 +13,8 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 
 	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw/internal"
 	"github.com/jacekolszak/pixiq/goimage"
 	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/keyboard"
-	"github.com/jacekolszak/pixiq/mouse"
 )
 
 // NewOpenGL creates OpenGL instance.
@@ -58,27 +54,12 @@ func NewOpenGL(mainThreadLoop *MainThreadLoop) (*OpenGL, error) {
 			job()
 		})
 	}
-	api := &context{
-		run: func(f func()) {
-			mainThreadLoop.executeCommand(command{
-				window:  mainWindow,
-				execute: f,
-			})
-		},
-		runAsync: func(f func()) {
-			mainThreadLoop.executeAsyncCommand(command{
-				window:  mainWindow,
-				execute: f,
-			})
-		},
-	}
 	openGL := &OpenGL{
 		mainThreadLoop:    mainThreadLoop,
 		runInOpenGLThread: runInOpenGLThread,
 		stopPollingEvents: make(chan struct{}),
 		mainWindow:        mainWindow,
-		api:               api,
-		context:           gl.NewContext(api),
+		context:           gl.NewContext(newContext(mainThreadLoop, mainWindow)),
 	}
 	go openGL.startPollingEvents(openGL.stopPollingEvents)
 	return openGL, nil
@@ -132,7 +113,6 @@ type OpenGL struct {
 	runInOpenGLThread func(func())
 	stopPollingEvents chan struct{}
 	mainWindow        *glfw.Window
-	api               gl.API
 	context           *gl.Context
 	windowsOpen       int
 }
@@ -223,84 +203,20 @@ func (m *mouseWindow) Zoom() int {
 
 // OpenWindow creates and shows Window.
 func (g *OpenGL) OpenWindow(width, height int, options ...WindowOption) (*Window, error) {
-	if width < 1 {
-		width = 1
-	}
-	if height < 1 {
-		height = 1
-	}
-	// FIXME: EventBuffer size should be configurable
-	keyboardEvents := internal.NewKeyboardEvents(keyboard.NewEventBuffer(32))
-	screenAcceleratedImage := g.context.NewAcceleratedImage(width, height)
-	screenImage := image.New(screenAcceleratedImage)
-	win := &Window{
-		mainThreadLoop:         g.mainThreadLoop,
-		keyboardEvents:         keyboardEvents,
-		requestedWidth:         width,
-		requestedHeight:        height,
-		screenImage:            screenImage,
-		screenAcceleratedImage: screenAcceleratedImage,
-		sharedContextAPI:       g.context.API(),
-		zoom:                   1,
-		title:                  "OpenGL Pixiq Window",
-	}
-	var err error
-	g.mainThreadLoop.Execute(func() {
-		if g.windowsOpen == 0 {
-			win.glfwWindow = g.mainWindow
-		} else {
-			win.glfwWindow, err = createWindow(g.mainThreadLoop, win.title, g.mainWindow)
-			if err != nil {
-				return
-			}
+	glfwWindow := g.mainWindow
+	winContext := g.context
+	if g.windowsOpen > 0 {
+		var err error
+		g.mainThreadLoop.Execute(func() {
+			glfwWindow, err = createWindow(g.mainThreadLoop, "OpenGL Pixiq Window", g.mainWindow)
+		})
+		if err != nil {
+			return nil, err
 		}
-		for _, option := range options {
-			if option == nil {
-				log.Println("nil option given when opening the window")
-				continue
-			}
-			option(win)
-		}
-		win.mouseWindow = &mouseWindow{
-			glfwWindow:     win.glfwWindow,
-			mainThreadLoop: g.mainThreadLoop,
-			zoom:           win.zoom,
-		}
-		win.mouseEvents = internal.NewMouseEvents(
-			// FIXME: EventBuffer size should be configurable
-			mouse.NewEventBuffer(32),
-			win.mouseWindow)
-		win.glfwWindow.SetKeyCallback(win.keyboardEvents.OnKeyCallback)
-		win.glfwWindow.SetMouseButtonCallback(win.mouseEvents.OnMouseButtonCallback)
-		win.glfwWindow.SetScrollCallback(win.mouseEvents.OnScrollCallback)
-		win.glfwWindow.SetSize(win.requestedWidth*win.zoom, win.requestedHeight*win.zoom)
-		win.glfwWindow.Show()
-	})
-	if err != nil {
-		return nil, err
+		api := newContext(g.mainThreadLoop, glfwWindow)
+		winContext = gl.NewContext(api)
 	}
-	if g.windowsOpen == 0 {
-		win.api = g.api
-		win.context = g.context
-	} else {
-		win.api = &context{
-			run: func(f func()) {
-				g.mainThreadLoop.executeCommand(command{
-					window:  win.glfwWindow,
-					execute: f,
-				})
-			},
-			runAsync: func(f func()) {
-				g.mainThreadLoop.executeAsyncCommand(command{
-					window:  win.glfwWindow,
-					execute: f,
-				})
-			},
-		}
-		win.context = gl.NewContext(win.api)
-	}
-	win.screenPolygon = newScreenPolygon(win.context, win.api)
-	win.program, err = compileProgram(win.context, vertexShaderSrc, fragmentShaderSrc)
+	win, err := newWindow(glfwWindow, g.mainThreadLoop, width, height, winContext, g.context, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +233,7 @@ func (g *OpenGL) Context() *gl.Context {
 // ContextAPI returns gl.API, which can be used to OpenGL direct access.
 // It's methods can be invoked from any goroutine.
 func (g *OpenGL) ContextAPI() gl.API {
-	return g.api
+	return g.context.API()
 }
 
 // WindowOption is an option used when opening the window.

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -185,20 +185,17 @@ func (m *mouseWindow) CursorPosition() (float64, float64) {
 	return x, y
 }
 
-// Size() is thread-safe
 func (m *mouseWindow) Size() (int, int) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	if m.width == 0 {
-		m.mainThreadLoop.Execute(func() {
-			m.width, m.height = m.glfwWindow.GetSize()
-		})
-	}
 	return m.width, m.height
 }
 
 func (m *mouseWindow) Zoom() int {
 	return m.zoom
+}
+
+func (m *mouseWindow) OnSizeCallback(_ *glfw.Window, width int, height int) {
+	m.width = width
+	m.height = height
 }
 
 // OpenWindow creates and shows Window.

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -185,17 +185,20 @@ func (m *mouseWindow) CursorPosition() (float64, float64) {
 	return x, y
 }
 
+// Size() is thread-safe
 func (m *mouseWindow) Size() (int, int) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.width == 0 {
+		m.mainThreadLoop.Execute(func() {
+			m.width, m.height = m.glfwWindow.GetSize()
+		})
+	}
 	return m.width, m.height
 }
 
 func (m *mouseWindow) Zoom() int {
 	return m.zoom
-}
-
-func (m *mouseWindow) OnSizeCallback(_ *glfw.Window, width int, height int) {
-	m.width = width
-	m.height = height
 }
 
 // OpenWindow creates and shows Window.

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -43,7 +43,7 @@ func NewOpenGL(mainThreadLoop *MainThreadLoop) (*OpenGL, error) {
 		if err != nil {
 			return
 		}
-		mainWindow, err = createWindow(mainThreadLoop, "OpenGL Pixiq Dummy Window", nil)
+		mainWindow, err = createWindow(mainThreadLoop, "OpenGL Pixiq Window", nil)
 	})
 	if err != nil {
 		return nil, err

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -216,7 +216,12 @@ func (g *OpenGL) OpenWindow(width, height int, options ...WindowOption) (*Window
 		api := newContext(g.mainThreadLoop, glfwWindow)
 		winContext = gl.NewContext(api)
 	}
-	win, err := newWindow(glfwWindow, g.mainThreadLoop, width, height, winContext, g.context, options...)
+	win, err := newWindow(glfwWindow, g.mainThreadLoop, width, height, winContext, g.context, func(window *Window) {
+		if glfwWindow != g.mainWindow {
+			g.mainThreadLoop.Execute(glfwWindow.Destroy)
+		}
+		g.windowsOpen--
+	}, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/glfw/glfw_test.go
+++ b/glfw/glfw_test.go
@@ -1,10 +1,12 @@
 package glfw_test
 
 import (
+	"os"
+	"sync"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
 
 	"github.com/jacekolszak/pixiq/glfw"
 )
@@ -321,6 +323,52 @@ func TestOpenGL_OpenWindow(t *testing.T) {
 				assert.Equal(t, title, win.Title())
 			})
 		}
+	})
+}
+
+func TestWindow_Width(t *testing.T) {
+	t.Run("concurrent Width() calls should return the same value", func(t *testing.T) {
+		openGL, err := glfw.NewOpenGL(mainThreadLoop)
+		require.NoError(t, err)
+		defer openGL.Destroy()
+		// when
+		win, err := openGL.OpenWindow(640, 360)
+		require.NoError(t, err)
+		defer win.Close()
+		// then
+		var wg sync.WaitGroup
+		goroutines := 100
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				assert.Equal(t, win.Width(), 640)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func TestWindow_Height(t *testing.T) {
+	t.Run("concurrent Height() calls should return the same value", func(t *testing.T) {
+		openGL, err := glfw.NewOpenGL(mainThreadLoop)
+		require.NoError(t, err)
+		defer openGL.Destroy()
+		// when
+		win, err := openGL.OpenWindow(640, 360)
+		require.NoError(t, err)
+		defer win.Close()
+		// then
+		var wg sync.WaitGroup
+		goroutines := 100
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				assert.Equal(t, win.Height(), 360)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
 	})
 }
 

--- a/glfw/glfw_test.go
+++ b/glfw/glfw_test.go
@@ -1,12 +1,10 @@
 package glfw_test
 
 import (
-	"os"
-	"sync"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
 
 	"github.com/jacekolszak/pixiq/glfw"
 )
@@ -323,52 +321,6 @@ func TestOpenGL_OpenWindow(t *testing.T) {
 				assert.Equal(t, title, win.Title())
 			})
 		}
-	})
-}
-
-func TestWindow_Width(t *testing.T) {
-	t.Run("concurrent Width() calls should return the same value", func(t *testing.T) {
-		openGL, err := glfw.NewOpenGL(mainThreadLoop)
-		require.NoError(t, err)
-		defer openGL.Destroy()
-		// when
-		win, err := openGL.OpenWindow(640, 360)
-		require.NoError(t, err)
-		defer win.Close()
-		// then
-		var wg sync.WaitGroup
-		goroutines := 100
-		wg.Add(goroutines)
-		for i := 0; i < goroutines; i++ {
-			go func() {
-				assert.Equal(t, win.Width(), 640)
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-	})
-}
-
-func TestWindow_Height(t *testing.T) {
-	t.Run("concurrent Height() calls should return the same value", func(t *testing.T) {
-		openGL, err := glfw.NewOpenGL(mainThreadLoop)
-		require.NoError(t, err)
-		defer openGL.Destroy()
-		// when
-		win, err := openGL.OpenWindow(640, 360)
-		require.NoError(t, err)
-		defer win.Close()
-		// then
-		var wg sync.WaitGroup
-		goroutines := 100
-		wg.Add(goroutines)
-		for i := 0; i < goroutines; i++ {
-			go func() {
-				assert.Equal(t, win.Height(), 360)
-				wg.Done()
-			}()
-		}
-		wg.Wait()
 	})
 }
 

--- a/glfw/glfw_test.go
+++ b/glfw/glfw_test.go
@@ -217,9 +217,26 @@ func TestOpenGL_OpenWindow(t *testing.T) {
 		require.NoError(t, err)
 		defer win2.Close()
 		// then
-		require.NotNil(t, win2)
 		assert.Equal(t, 320, win2.Width())
 		assert.Equal(t, 180, win2.Height())
+	})
+	t.Run("should open another Window after first, then second were closed", func(t *testing.T) {
+		openGL, err := glfw.NewOpenGL(mainThreadLoop)
+		require.NoError(t, err)
+		defer openGL.Destroy()
+		win1, err := openGL.OpenWindow(640, 360)
+		require.NoError(t, err)
+		win1.Close()
+		win2, err := openGL.OpenWindow(320, 180)
+		require.NoError(t, err)
+		win2.Close()
+		// when
+		win3, err := openGL.OpenWindow(160, 90)
+		require.NoError(t, err)
+		defer win3.Close()
+		// then
+		assert.Equal(t, 160, win2.Width())
+		assert.Equal(t, 90, win2.Height())
 	})
 	t.Run("should skip nil option", func(t *testing.T) {
 		openGL, err := glfw.NewOpenGL(mainThreadLoop)

--- a/glfw/polygons.go
+++ b/glfw/polygons.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jacekolszak/pixiq/gl"
 )
 
-func newScreenPolygon(context *gl.Context, api gl.API) *screenPolygon {
+func newScreenPolygon(context *gl.Context) *screenPolygon {
 	const (
 		vertexLocation  = 0
 		textureLocation = 1
@@ -31,7 +31,7 @@ func newScreenPolygon(context *gl.Context, api gl.API) *screenPolygon {
 		Offset: 2,
 		Stride: 4,
 	})
-	return &screenPolygon{vertexArrayID: vao.ID(), api: api}
+	return &screenPolygon{vertexArrayID: vao.ID(), api: context.API()}
 }
 
 type screenPolygon struct {

--- a/glfw/polygons.go
+++ b/glfw/polygons.go
@@ -31,15 +31,21 @@ func newScreenPolygon(context *gl.Context) *screenPolygon {
 		Offset: 2,
 		Stride: 4,
 	})
-	return &screenPolygon{vertexArrayID: vao.ID(), api: context.API()}
+	return &screenPolygon{vao: vao, vbo: buffer, api: context.API()}
 }
 
 type screenPolygon struct {
-	vertexArrayID uint32
-	api           gl.API
+	vao *gl.VertexArray
+	vbo *gl.FloatVertexBuffer
+	api gl.API
 }
 
 func (p *screenPolygon) draw() {
-	p.api.BindVertexArray(p.vertexArrayID)
+	p.api.BindVertexArray(p.vao.ID())
 	p.api.DrawArrays(gl33.TRIANGLE_FAN, 0, 4)
+}
+
+func (p *screenPolygon) delete() {
+	p.vao.Delete()
+	p.vbo.Delete()
 }

--- a/glfw/program.go
+++ b/glfw/program.go
@@ -9,10 +9,12 @@ func compileProgram(context *gl.Context, vertexShaderSrc, fragmentShaderSrc stri
 	if err != nil {
 		return nil, err
 	}
+	defer vertexShader.Delete()
 	fragmentShader, err := context.CompileFragmentShader(fragmentShaderSrc)
 	if err != nil {
 		return nil, err
 	}
+	defer fragmentShader.Delete()
 	program, err := context.LinkProgram(vertexShader, fragmentShader)
 	if err != nil {
 		return nil, err

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -140,7 +140,12 @@ func (w *Window) Close() {
 	if w.closed {
 		return
 	}
-	w.mainThreadLoop.Execute(w.glfwWindow.Hide)
+	w.mainThreadLoop.Execute(func() {
+		w.glfwWindow.SetKeyCallback(nil)
+		w.glfwWindow.SetMouseButtonCallback(nil)
+		w.glfwWindow.SetScrollCallback(nil)
+		w.glfwWindow.Hide()
+	})
 	w.screenPolygon.delete()
 	w.program.Delete()
 	w.screenImage.Delete()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -3,6 +3,7 @@ package glfw
 import (
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"log"
 
 	"github.com/jacekolszak/pixiq/gl"
 	"github.com/jacekolszak/pixiq/glfw/internal"
@@ -24,11 +25,62 @@ type Window struct {
 	title                  string
 	screenImage            *image.Image
 	screenAcceleratedImage *gl.AcceleratedImage
-	sharedContextAPI       gl.API // API for main context shared between all windows
-	api                    gl.API
+	sharedContext          *gl.Context // API for main context shared between all windows
 	context                *gl.Context
 	program                *gl.Program
 	mouseWindow            *mouseWindow
+}
+
+func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, height int, context *gl.Context, sharedContext *gl.Context, options ...WindowOption) (*Window, error) {
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+	screenAcceleratedImage := sharedContext.NewAcceleratedImage(width, height)
+	program, err := compileProgram(context, vertexShaderSrc, fragmentShaderSrc)
+	if err != nil {
+		return nil, err
+	}
+	win := &Window{
+		glfwWindow:             glfwWindow,
+		mainThreadLoop:         mainThreadLoop,
+		screenPolygon:          newScreenPolygon(context),
+		keyboardEvents:         internal.NewKeyboardEvents(keyboard.NewEventBuffer(32)), // FIXME: EventBuffer size should be configurable
+		requestedWidth:         width,
+		requestedHeight:        height,
+		zoom:                   1,
+		title:                  "OpenGL Pixiq Window",
+		screenImage:            image.New(screenAcceleratedImage),
+		screenAcceleratedImage: screenAcceleratedImage,
+		sharedContext:          sharedContext,
+		context:                context,
+		program:                program,
+	}
+	mainThreadLoop.Execute(func() {
+		for _, option := range options {
+			if option == nil {
+				log.Println("nil option given when opening the window")
+				continue
+			}
+			option(win)
+		}
+		win.mouseWindow = &mouseWindow{
+			glfwWindow:     win.glfwWindow,
+			mainThreadLoop: mainThreadLoop,
+			zoom:           win.zoom,
+		}
+		win.mouseEvents = internal.NewMouseEvents(
+			mouse.NewEventBuffer(32), // FIXME: EventBuffer size should be configurable
+			win.mouseWindow)
+		win.glfwWindow.SetKeyCallback(win.keyboardEvents.OnKeyCallback)
+		win.glfwWindow.SetMouseButtonCallback(win.mouseEvents.OnMouseButtonCallback)
+		win.glfwWindow.SetScrollCallback(win.mouseEvents.OnScrollCallback)
+		win.glfwWindow.SetSize(win.requestedWidth*win.zoom, win.requestedHeight*win.zoom)
+		win.glfwWindow.Show()
+	})
+	return win, nil
 }
 
 // PollMouseEvent retrieves and removes next mouse Event. If there are no more
@@ -49,20 +101,21 @@ func (w *Window) DrawIntoBackBuffer() {
 	w.screenImage.Upload()
 	// Finish actively polls GPU which may consume a lot of CPU power.
 	// That's why Finish is called only if context synchronization is required
-	if w.sharedContextAPI != w.api {
-		w.sharedContextAPI.Finish()
+	api := w.context.API()
+	if w.sharedContext.API() != api {
+		w.sharedContext.API().Finish()
 	}
 	var width, height int
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()
 	})
-	w.api.Enable(gl33.BLEND) // this should be disabled instead
-	w.api.BlendFunc(1, 0)    // and then this is not required
-	w.api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
-	w.api.Viewport(0, 0, int32(width), int32(height))
-	w.api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled instead
-	w.api.BindTexture(gl33.TEXTURE_2D, w.screenAcceleratedImage.TextureID())
-	w.api.UseProgram(w.program.ID())
+	api.Enable(gl33.BLEND) // this should be disabled instead
+	api.BlendFunc(1, 0)    // and then this is not required
+	api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
+	api.Viewport(0, 0, int32(width), int32(height))
+	api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled instead
+	api.BindTexture(gl33.TEXTURE_2D, w.screenAcceleratedImage.TextureID())
+	api.UseProgram(w.program.ID())
 	w.screenPolygon.draw()
 }
 
@@ -133,7 +186,7 @@ func (w *Window) Screen() image.Selection {
 // ContextAPI returns window-specific OpenGL's context. Useful for accessing
 // window's framebuffer.
 func (w *Window) ContextAPI() gl.API {
-	return w.api
+	return w.context.API()
 }
 
 // SetCursor sets the window cursor

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -49,7 +49,7 @@ func (w *Window) Draw() {
 func (w *Window) DrawIntoBackBuffer() {
 	w.screenImage.Upload()
 	// Finish actively polls GPU which may consume a lot of CPU power.
-	// That's why Finish is called only if necessary
+	// That's why Finish is called only if context synchronization is required
 	if w.sharedContextAPI != w.api {
 		w.sharedContextAPI.Finish()
 	}

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -118,11 +118,10 @@ func (w *Window) DrawIntoBackBuffer() {
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()
 	})
-	api.Enable(gl33.BLEND) // this should be disabled instead
-	api.BlendFunc(1, 0)    // and then this is not required
+	api.Disable(gl33.BLEND)
+	api.Disable(gl33.SCISSOR_TEST)
 	api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
 	api.Viewport(0, 0, int32(width), int32(height))
-	api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled instead
 	api.BindTexture(gl33.TEXTURE_2D, w.screenAcceleratedImage.TextureID())
 	api.UseProgram(w.program.ID())
 	w.screenPolygon.draw()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -69,14 +69,10 @@ func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, h
 			}
 			option(win)
 		}
-		w := win.requestedWidth * win.zoom
-		h := win.requestedHeight * win.zoom
 		win.mouseWindow = &mouseWindow{
 			glfwWindow:     win.glfwWindow,
 			mainThreadLoop: mainThreadLoop,
 			zoom:           win.zoom,
-			width:          w,
-			height:         h,
 		}
 		win.mouseEvents = internal.NewMouseEvents(
 			mouse.NewEventBuffer(32), // FIXME: EventBuffer size should be configurable
@@ -84,8 +80,7 @@ func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, h
 		win.glfwWindow.SetKeyCallback(win.keyboardEvents.OnKeyCallback)
 		win.glfwWindow.SetMouseButtonCallback(win.mouseEvents.OnMouseButtonCallback)
 		win.glfwWindow.SetScrollCallback(win.mouseEvents.OnScrollCallback)
-		win.glfwWindow.SetSizeCallback(win.mouseWindow.OnSizeCallback)
-		win.glfwWindow.SetSize(w, h)
+		win.glfwWindow.SetSize(win.requestedWidth*win.zoom, win.requestedHeight*win.zoom)
 		win.glfwWindow.Show()
 	})
 	return win, nil
@@ -145,13 +140,7 @@ func (w *Window) Close() {
 	if w.closed {
 		return
 	}
-	w.mainThreadLoop.Execute(func() {
-		w.glfwWindow.SetKeyCallback(nil)
-		w.glfwWindow.SetMouseButtonCallback(nil)
-		w.glfwWindow.SetScrollCallback(nil)
-		w.glfwWindow.SetSizeCallback(nil)
-		w.glfwWindow.Hide()
-	})
+	w.mainThreadLoop.Execute(w.glfwWindow.Hide)
 	w.screenPolygon.delete()
 	w.program.Delete()
 	w.screenImage.Delete()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -24,12 +24,11 @@ type Window struct {
 	title                  string
 	screenImage            *image.Image
 	screenAcceleratedImage *gl.AcceleratedImage
-	// API for main context shared between all windows
-	sharedContextAPI gl.API
-	api              gl.API
-	context          *gl.Context
-	program          *gl.Program
-	mouseWindow      *mouseWindow
+	sharedContextAPI       gl.API // API for main context shared between all windows
+	api                    gl.API
+	context                *gl.Context
+	program                *gl.Program
+	mouseWindow            *mouseWindow
 }
 
 // PollMouseEvent retrieves and removes next mouse Event. If there are no more
@@ -74,8 +73,11 @@ func (w *Window) SwapBuffers() {
 
 // Close closes the window and cleans resources.
 func (w *Window) Close() {
+	w.mainThreadLoop.Execute(w.glfwWindow.Hide)
 	// TODO decrease number of windows
-	w.mainThreadLoop.Execute(w.glfwWindow.Destroy)
+	// TODO Delete screen image, program, VAO etc.
+	// TODO Destroy window only if it is not main
+	//w.mainThreadLoop.Execute(w.glfwWindow.Destroy)
 }
 
 // ShouldClose reports the value of the close flag of the window.

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -1,6 +1,8 @@
 package glfw
 
 import (
+	"log"
+
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 	"github.com/jacekolszak/pixiq/gl"
@@ -8,7 +10,6 @@ import (
 	"github.com/jacekolszak/pixiq/image"
 	"github.com/jacekolszak/pixiq/keyboard"
 	"github.com/jacekolszak/pixiq/mouse"
-	"log"
 )
 
 // Window is an implementation of loop.Screen and keyboard.EventSource

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -1,10 +1,10 @@
 package glfw
 
 import (
-	gl33 "github.com/go-gl/gl/v3.3-core/gl"
-	"github.com/go-gl/glfw/v3.3/glfw"
 	"log"
 
+	gl33 "github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/go-gl/glfw/v3.3/glfw"
 	"github.com/jacekolszak/pixiq/gl"
 	"github.com/jacekolszak/pixiq/glfw/internal"
 	"github.com/jacekolszak/pixiq/image"

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -56,11 +56,11 @@ func (w *Window) DrawIntoBackBuffer() {
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()
 	})
-	// FIXME Better run Command here.
-	w.api.BlendFunc(1, 0)
+	w.api.Enable(gl33.BLEND) // this should be disabled
+	w.api.BlendFunc(1, 0)    // and then this is not required
 	w.api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
 	w.api.Viewport(0, 0, int32(width), int32(height))
-	w.api.Scissor(0, 0, int32(width), int32(height))
+	w.api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled
 	w.api.BindTexture(gl33.TEXTURE_2D, w.screenAcceleratedImage.TextureID())
 	w.api.UseProgram(w.program.ID())
 	w.screenPolygon.draw()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -56,11 +56,11 @@ func (w *Window) DrawIntoBackBuffer() {
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()
 	})
-	w.api.Enable(gl33.BLEND) // this should be disabled
+	w.api.Enable(gl33.BLEND) // this should be disabled instead
 	w.api.BlendFunc(1, 0)    // and then this is not required
 	w.api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
 	w.api.Viewport(0, 0, int32(width), int32(height))
-	w.api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled
+	w.api.Scissor(0, 0, int32(width), int32(height)) // scissor should be disabled instead
 	w.api.BindTexture(gl33.TEXTURE_2D, w.screenAcceleratedImage.TextureID())
 	w.api.UseProgram(w.program.ID())
 	w.screenPolygon.draw()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -142,7 +142,9 @@ func (w *Window) Close() {
 		return
 	}
 	w.mainThreadLoop.Execute(w.glfwWindow.Hide)
-	// TODO Delete screen image, program, VAO etc.
+	w.screenPolygon.delete()
+	w.program.Delete()
+	w.screenImage.Delete()
 	w.onClose(w)
 	w.closed = true
 }

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -69,10 +69,14 @@ func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, h
 			}
 			option(win)
 		}
+		w := win.requestedWidth * win.zoom
+		h := win.requestedHeight * win.zoom
 		win.mouseWindow = &mouseWindow{
 			glfwWindow:     win.glfwWindow,
 			mainThreadLoop: mainThreadLoop,
 			zoom:           win.zoom,
+			width:          w,
+			height:         h,
 		}
 		win.mouseEvents = internal.NewMouseEvents(
 			mouse.NewEventBuffer(32), // FIXME: EventBuffer size should be configurable
@@ -80,7 +84,8 @@ func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, h
 		win.glfwWindow.SetKeyCallback(win.keyboardEvents.OnKeyCallback)
 		win.glfwWindow.SetMouseButtonCallback(win.mouseEvents.OnMouseButtonCallback)
 		win.glfwWindow.SetScrollCallback(win.mouseEvents.OnScrollCallback)
-		win.glfwWindow.SetSize(win.requestedWidth*win.zoom, win.requestedHeight*win.zoom)
+		win.glfwWindow.SetSizeCallback(win.mouseWindow.OnSizeCallback)
+		win.glfwWindow.SetSize(w, h)
 		win.glfwWindow.Show()
 	})
 	return win, nil
@@ -140,7 +145,13 @@ func (w *Window) Close() {
 	if w.closed {
 		return
 	}
-	w.mainThreadLoop.Execute(w.glfwWindow.Hide)
+	w.mainThreadLoop.Execute(func() {
+		w.glfwWindow.SetKeyCallback(nil)
+		w.glfwWindow.SetMouseButtonCallback(nil)
+		w.glfwWindow.SetScrollCallback(nil)
+		w.glfwWindow.SetSizeCallback(nil)
+		w.glfwWindow.Hide()
+	})
 	w.screenPolygon.delete()
 	w.program.Delete()
 	w.screenImage.Delete()

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -57,6 +57,8 @@ func (w *Window) DrawIntoBackBuffer() {
 	w.mainThreadLoop.Execute(func() {
 		width, height = w.glfwWindow.GetFramebufferSize()
 	})
+	// FIXME Better run Command here.
+	w.api.BlendFunc(1, 0)
 	w.api.BindFramebuffer(gl33.FRAMEBUFFER, 0)
 	w.api.Viewport(0, 0, int32(width), int32(height))
 	w.api.Scissor(0, 0, int32(width), int32(height))

--- a/glfw/window_test.go
+++ b/glfw/window_test.go
@@ -228,6 +228,88 @@ func TestWindow_DrawIntoBackBuffer(t *testing.T) {
 
 		})
 	})
+
+	t.Run("should panic for closed window", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win, _ := openGL.OpenWindow(1, 1)
+		win.Close()
+		assert.Panics(t, func() {
+			// when
+			win.DrawIntoBackBuffer()
+		})
+	})
+
+}
+
+func TestWindow_Draw(t *testing.T) {
+	t.Run("should panic for closed window", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win, _ := openGL.OpenWindow(1, 1)
+		win.Close()
+		assert.Panics(t, func() {
+			// when
+			win.Draw()
+		})
+	})
+}
+
+func TestWindow_SwapBuffers(t *testing.T) {
+	t.Run("should panic for closed window", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win, _ := openGL.OpenWindow(1, 1)
+		win.Close()
+		assert.Panics(t, func() {
+			// when
+			win.SwapBuffers()
+		})
+	})
+}
+
+func TestWindow_Close(t *testing.T) {
+	t.Run("second Close does nothing", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win, _ := openGL.OpenWindow(1, 1)
+		win.Close()
+		// when
+		win.Close()
+	})
+	t.Run("second Close on a second open window does nothing", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win1, _ := openGL.OpenWindow(1, 1)
+		defer win1.Close()
+		win2, _ := openGL.OpenWindow(1, 1)
+		win2.Close()
+		// when
+		win2.Close()
+	})
+}
+
+func TestWindow_ShouldClose(t *testing.T) {
+	t.Run("ShouldClose on closed window returns false", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win, _ := openGL.OpenWindow(1, 1)
+		win.Close()
+		// when
+		shouldClose := win.ShouldClose()
+		assert.False(t, shouldClose)
+	})
+	t.Run("ShouldClose on a second closed window returns false", func(t *testing.T) {
+		openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+		defer openGL.Destroy()
+		win1, _ := openGL.OpenWindow(1, 1)
+		defer win1.Close()
+		win2, _ := openGL.OpenWindow(1, 1)
+		win2.Close()
+		// when
+		shouldClose := win2.ShouldClose()
+		assert.False(t, shouldClose)
+	})
 }
 
 func windowOfColor(openGL *glfw.OpenGL, color image.Color) (*glfw.Window, error) {

--- a/glfw/window_test.go
+++ b/glfw/window_test.go
@@ -174,6 +174,59 @@ func TestWindow_DrawIntoBackBuffer(t *testing.T) {
 			expected = []image.Color{color2}
 			assert.Equal(t, expected, framebufferPixels(window2.ContextAPI(), 0, 0, 1, 1))
 		})
+
+		t.Run("should draw screen despite the state of OpenGL context", func(t *testing.T) {
+			tests := map[string]func(ctx *gl2.Context, win *glfw.Window){
+				"BlendFunc": func(ctx *gl2.Context, win *glfw.Window) {
+					ctx.API().Enable(gl.BLEND)
+					ctx.API().BlendFunc(0, 0)
+				},
+				"BindFramebuffer": func(ctx *gl2.Context, win *glfw.Window) {
+					var fb uint32
+					ctx.API().GenFramebuffers(1, &fb)
+					ctx.API().BindFramebuffer(gl.FRAMEBUFFER, fb)
+				},
+				"Viewport": func(ctx *gl2.Context, win *glfw.Window) {
+					ctx.API().Viewport(0, 0, 0, 0)
+				},
+				"Scissor": func(ctx *gl2.Context, win *glfw.Window) {
+					ctx.API().Enable(gl.SCISSOR_TEST)
+					ctx.API().Scissor(0, 0, 0, 0)
+				},
+				"BindTexture": func(ctx *gl2.Context, win *glfw.Window) {
+					img := ctx.NewAcceleratedImage(1, 1)
+					img.Upload([]image.Color{image.RGBA(0, 0, 0, 0)})
+					texture := img.TextureID()
+					ctx.API().BindTexture(gl.TEXTURE_2D, texture)
+				},
+				"BindTexture when screen is uploaded": func(ctx *gl2.Context, win *glfw.Window) {
+					win.Screen().Image().Upload()
+					img := ctx.NewAcceleratedImage(1, 1)
+					img.Upload([]image.Color{image.RGBA(0, 0, 0, 0)})
+					texture := img.TextureID()
+					ctx.API().BindTexture(gl.TEXTURE_2D, texture)
+				},
+				"UseProgram": func(ctx *gl2.Context, win *glfw.Window) {
+					program := ctx.API().CreateProgram()
+					ctx.API().UseProgram(program)
+				},
+			}
+			for name, testFunction := range tests {
+				t.Run(name, func(t *testing.T) {
+					openGL, _ := glfw.NewOpenGL(mainThreadLoop)
+					defer openGL.Destroy()
+					win, _ := windowOfColor(openGL, color1)
+					defer win.Close()
+					// when
+					testFunction(openGL.Context(), win)
+					win.DrawIntoBackBuffer()
+					// then
+					expected := []image.Color{color1}
+					assert.Equal(t, expected, framebufferPixels(win.ContextAPI(), 0, 0, 1, 1))
+				})
+			}
+
+		})
 	})
 }
 

--- a/image/fake/fake.go
+++ b/image/fake/fake.go
@@ -77,10 +77,12 @@ func (i *AcceleratedImage) PixelsTable() [][]image.Color {
 	return table
 }
 
+// Delete marks AcceleratedImage as deleted
 func (i *AcceleratedImage) Delete() {
 	i.deleted = true
 }
 
+// Deleted returns true if AcceleratedImage.Delete() method was called
 func (i *AcceleratedImage) Deleted() bool {
 	return i.deleted
 }

--- a/image/fake/fake.go
+++ b/image/fake/fake.go
@@ -28,9 +28,10 @@ func NewAcceleratedImage(width, height int) *AcceleratedImage {
 // AcceleratedImage stores pixel data in RAM and uses CPU solely.
 type AcceleratedImage struct {
 	// Hide the instance variable
-	pixels []image.Color
-	width  int
-	height int
+	pixels  []image.Color
+	width   int
+	height  int
+	deleted bool
 }
 
 // Upload send pixels to a container in RAM
@@ -74,4 +75,12 @@ func (i *AcceleratedImage) PixelsTable() [][]image.Color {
 		}
 	}
 	return table
+}
+
+func (i *AcceleratedImage) Delete() {
+	i.deleted = true
+}
+
+func (i *AcceleratedImage) Deleted() bool {
+	return i.deleted
 }

--- a/image/fake/fake_test.go
+++ b/image/fake/fake_test.go
@@ -223,3 +223,10 @@ func TestAcceleratedImage_PixelsTable(t *testing.T) {
 		}
 	})
 }
+
+func TestAcceleratedImage_Delete(t *testing.T) {
+	img := fake.NewAcceleratedImage(1, 1)
+	// when
+	img.Delete()
+	assert.True(t, img.Deleted())
+}

--- a/image/image.go
+++ b/image/image.go
@@ -26,6 +26,9 @@ type AcceleratedImage interface {
 	Width() int
 	// Height returns the number of pixels in a column.
 	Height() int
+	// Delete cleans resources, usually pixels stored in external memory (such as VRAM).
+	// After AcceleratedImage is deleted it cannot be used anymore.
+	Delete()
 }
 
 // New creates an Image with same size as provided AcceleratedImage.
@@ -107,6 +110,12 @@ func (i *Image) Upload() {
 		i.acceleratedImage.Upload(i.pixels)
 		i.ramModified = false
 	}
+}
+
+// Delete cleans resources allocated outside the Go heap. This method must be
+// called if you are going to create a number of short-lived images.
+func (i *Image) Delete() {
+	i.acceleratedImage.Delete()
 }
 
 // Selection points to a specific area of the image. It has a starting position

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -521,6 +521,17 @@ func TestImage_Upload(t *testing.T) {
 	})
 }
 
+func TestImage_Delete(t *testing.T) {
+	t.Run("Delete should delete AcceleratedImage", func(t *testing.T) {
+		acceleratedImage := fake.NewAcceleratedImage(1, 1)
+		img := image.New(acceleratedImage)
+		// when
+		img.Delete()
+		// then
+		assert.True(t, acceleratedImage.Deleted())
+	})
+}
+
 func TestSelection_Modify(t *testing.T) {
 	t.Run("should execute command", func(t *testing.T) {
 		acceleratedImage := fake.NewAcceleratedImage(1, 1)
@@ -1228,6 +1239,7 @@ func (i acceleratedImageStub) Width() int {
 func (i acceleratedImageStub) Height() int {
 	return i.height
 }
+func (i acceleratedImageStub) Delete() {}
 
 type acceleratedCommandMock struct {
 	timesExecuted int


### PR DESCRIPTION
Having two OpenGL contexts is expensive, especially on Nvidia drivers. There are two reasons for this:
* binding the context to a thread is very expensive (`glfwMakeContextCurrent`)
* in order to share resources between contexts (such as textures), you need to synchronize them, e.g. with `glFinish`. This operation on some drivers (especially Linux, NVidia) actively polls the GPU, which in turn increases the CPU consumption.

However, most games don't need two OpenGL contexts because they only open one window at a time. At startup, Pixiq opens a hidden window so that game developer can use OpenGL. It has a context, which is then shared between all open windows. The context contains all images for use in any window. We can perform a simple optimization of reusing this hidden window. When game opens a window and there are not open windows it can reuse the shared hidden window by resizing it and making it visible.
