### PR TITLE
Fix mouse concurrency issues

### DIFF
--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -6,7 +6,6 @@
 package glfw
 
 import (
-	"sync"
 	"time"
 
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
@@ -170,31 +169,17 @@ func (g *OpenGL) NewImage(width, height int) *image.Image {
 
 // mouseWindow implements mouse.Window
 type mouseWindow struct {
-	mutex          sync.Mutex
-	glfwWindow     *glfw.Window
-	mainThreadLoop *MainThreadLoop
-	zoom           int
-	width, height  int
+	glfwWindow *glfw.Window
+	zoom       int
 }
 
 func (m *mouseWindow) CursorPosition() (float64, float64) {
-	var x, y float64
-	m.mainThreadLoop.Execute(func() {
-		x, y = m.glfwWindow.GetCursorPos()
-	})
-	return x, y
+	return m.glfwWindow.GetCursorPos()
 }
 
 // Size() is thread-safe
 func (m *mouseWindow) Size() (int, int) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	if m.width == 0 {
-		m.mainThreadLoop.Execute(func() {
-			m.width, m.height = m.glfwWindow.GetSize()
-		})
-	}
-	return m.width, m.height
+	return m.glfwWindow.GetSize()
 }
 
 func (m *mouseWindow) Zoom() int {

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -71,9 +71,8 @@ func newWindow(glfwWindow *glfw.Window, mainThreadLoop *MainThreadLoop, width, h
 			option(win)
 		}
 		win.mouseWindow = &mouseWindow{
-			glfwWindow:     win.glfwWindow,
-			mainThreadLoop: mainThreadLoop,
-			zoom:           win.zoom,
+			glfwWindow: win.glfwWindow,
+			zoom:       win.zoom,
 		}
 		win.mouseEvents = internal.NewMouseEvents(
 			mouse.NewEventBuffer(32), // FIXME: EventBuffer size should be configurable
@@ -107,8 +106,11 @@ func updateSize(win *Window) <-chan bool {
 
 // PollMouseEvent retrieves and removes next mouse Event. If there are no more
 // events false is returned. It implements mouse.EventSource method.
-func (w *Window) PollMouseEvent() (mouse.Event, bool) {
-	return w.mouseEvents.Poll()
+func (w *Window) PollMouseEvent() (event mouse.Event, ok bool) {
+	w.mainThreadLoop.Execute(func() {
+		event, ok = w.mouseEvents.Poll()
+	})
+	return
 }
 
 // Draw draws a screen image in the window
@@ -206,15 +208,11 @@ func (w *Window) Zoom() int {
 
 // PollKeyboardEvent retrieves and removes next keyboard Event. If there are no more
 // events false is returned. It implements keyboard.EventSource method.
-func (w *Window) PollKeyboardEvent() (keyboard.Event, bool) {
-	var (
-		event keyboard.Event
-		ok    bool
-	)
+func (w *Window) PollKeyboardEvent() (event keyboard.Event, ok bool) {
 	w.mainThreadLoop.Execute(func() {
 		event, ok = w.keyboardEvents.Poll()
 	})
-	return event, ok
+	return
 }
 
 // Screen returns the image.Selection for the whole Window image


### PR DESCRIPTION
Pixiq is using 2 go-routines. First one - main thread for executing GLFW stuff and OpenGL, second one for main game loop. No structures should be shared between them. Unfortunately it is not the case for `Window.PollMouseEvent()` and `MouseEvents` callbacks. PollMouseEvent is beeing called by main game loop, MouseEvents callback by main thread. Therefore MouseEvents state is modified in two goroutines simultaneously which is not safe and might trigger errors in the future.