### PR TITLE
Rename module to github.com/elgopher/pixiq

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Oh yes, you can contribute! No matter what you do, we will be very grateful :)
 **Pixiq is very young project, so by contributing you can have a great impact of how it will be designed and implemented**.
 
 Some ways to contribute:
-1. Help with resolving [issues](https://github.com/jacekolszak/pixiq/issues): comment, discuss, make Pull Request reviews, suggest changes, help with documentation (improve existing and create new one) and if you are ready - make your own Pull Requests :) 
+1. Help with resolving [issues](https://github.com/elgopher/pixiq/issues): comment, discuss, make Pull Request reviews, suggest changes, help with documentation (improve existing and create new one) and if you are ready - make your own Pull Requests :) 
 2. Play with API and suggest improvements based on your experience 
 3. Create your very own libraries, abstractions, tools, examples and tutorials and let us know about it! We will spread the world.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pixiq
 
-[![CircleCI](https://circleci.com/gh/jacekolszak/pixiq.svg?style=svg)](https://circleci.com/gh/jacekolszak/pixiq)
-[![GoDoc](https://godoc.org/github.com/jacekolszak/pixiq?status.svg)](https://pkg.go.dev/mod/github.com/jacekolszak/pixiq)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jacekolszak/pixiq)](https://goreportcard.com/report/github.com/jacekolszak/pixiq)
+[![CircleCI](https://circleci.com/gh/elgopher/pixiq.svg?style=svg)](https://circleci.com/gh/elgopher/pixiq)
+[![GoDoc](https://godoc.org/github.com/elgopher/pixiq?status.svg)](https://pkg.go.dev/mod/github.com/elgopher/pixiq)
+[![Go Report Card](https://goreportcard.com/badge/github.com/elgopher/pixiq)](https://goreportcard.com/report/github.com/elgopher/pixiq)
 
 Create Pixel Art games in Golang with fun and ease.
 
@@ -30,15 +30,15 @@ Create Pixel Art games in Golang with fun and ease.
 
 ```
 $ go mod init hello
-$ go get -u github.com/jacekolszak/pixiq
+$ go get -u github.com/elgopher/pixiq
 ```
 
 ```go
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 func main() {

--- a/blend/blend.go
+++ b/blend/blend.go
@@ -5,7 +5,7 @@
 package blend
 
 import (
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // ColorBlender blends source and target colors together. It is executed by Tool

--- a/blend/blend_bench_test.go
+++ b/blend/blend_bench_test.go
@@ -3,9 +3,9 @@ package blend_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/blend"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/blend"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 var resolutions = map[string]struct {

--- a/blend/blend_test.go
+++ b/blend/blend_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/blend"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/blend"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/clear/clear.go
+++ b/clear/clear.go
@@ -3,7 +3,7 @@
 package clear
 
 import (
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // New returns new instance of *clear.Tool

--- a/clear/clear_bench_test.go
+++ b/clear/clear_bench_test.go
@@ -3,9 +3,9 @@ package clear_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/clear"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/clear"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func BenchmarkTool_Clear(b *testing.B) {

--- a/clear/clear_test.go
+++ b/clear/clear_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/clear"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/clear"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/colornames/colornames.go
+++ b/colornames/colornames.go
@@ -6,7 +6,7 @@
 package colornames
 
 import (
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 var (

--- a/colornames/colornames_test.go
+++ b/colornames/colornames_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 func Test(t *testing.T) {

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -8,7 +8,7 @@ import (
 	_ "image/png" // Register PNG decoder
 	"os"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // ImageFactory creates a new image with given dimensions.

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/decoder"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/decoder"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ Why there is no abstraction for opening windows?
 
 > Because it is really hard to design such abstraction. There are way too many
 platforms varying in possibilities (PCs, Macs, mobile devices etc.). But we are
-open for [proposals](https://github.com/jacekolszak/pixiq/issues). There is 
+open for [proposals](https://github.com/elgopher/pixiq/issues). There is 
 a chance that it will be feasible to create such abstraction just for PCs 
 (Win, Mac and Linux).
 
@@ -57,8 +57,8 @@ for example it does not allow to change the look of the cursor or to set
 the window transparency. Why?
 
 > Because we haven't had time to do it yet. If something is really important
-for you then propably it is time to submit an  [Issue](https://github.com/jacekolszak/pixiq/issues) 
-or maybe even make a change by submitting a [Pull Request](https://github.com/jacekolszak/pixiq/pulls).
+for you then propably it is time to submit an  [Issue](https://github.com/elgopher/pixiq/issues) 
+or maybe even make a change by submitting a [Pull Request](https://github.com/elgopher/pixiq/pulls).
 The `glfw.OpenGL` struct does not need to implement any abstractions
 for opening windows, therefore it may be extended freely.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,4 +10,4 @@
 
 * unfortunetly it is not possible to have only automated tests.
 * some tests require manual work. 
-* before merging each PR it should be tested manually using all [examples](https://github.com/jacekolszak/pixiq/tree/master/examples)
+* before merging each PR it should be tested manually using all [examples](https://github.com/elgopher/pixiq/tree/master/examples)

--- a/examples/blend/main.go
+++ b/examples/blend/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/blend"
-	"github.com/jacekolszak/pixiq/clear"
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glblend"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/blend"
+	"github.com/elgopher/pixiq/clear"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glblend"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 func main() {

--- a/examples/clear/main.go
+++ b/examples/clear/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/clear"
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glclear"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/clear"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glclear"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 type clearTool interface {

--- a/examples/cursor/main.go
+++ b/examples/cursor/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func main() {

--- a/examples/decoder/main.go
+++ b/examples/decoder/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/blend"
-	"github.com/jacekolszak/pixiq/decoder"
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/blend"
+	"github.com/elgopher/pixiq/decoder"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 func main() {

--- a/examples/goimage/main.go
+++ b/examples/goimage/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"image"
 
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/goimage"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/goimage"
 )
 
 func main() {

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 func main() {

--- a/examples/image/lines/main.go
+++ b/examples/image/lines/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 // This example shows how to set all pixels using Lines

--- a/examples/image/main.go
+++ b/examples/image/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 // This program shows how to create an Image and manipulate its pixels.

--- a/examples/image/modify/opengl/draw/main.go
+++ b/examples/image/modify/opengl/draw/main.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 func main() {

--- a/examples/image/modify/opengl/selection/main.go
+++ b/examples/image/modify/opengl/selection/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 func main() {

--- a/examples/keyboard/justpressed/main.go
+++ b/examples/keyboard/justpressed/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func main() {

--- a/examples/keyboard/pressed/main.go
+++ b/examples/keyboard/pressed/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func main() {

--- a/examples/keyboard/pressedkeys/main.go
+++ b/examples/keyboard/pressedkeys/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func main() {

--- a/examples/mouse/position/main.go
+++ b/examples/mouse/position/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/clear"
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/clear"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func main() {

--- a/examples/mouse/pressed/main.go
+++ b/examples/mouse/pressed/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func main() {

--- a/examples/mouse/scroll/main.go
+++ b/examples/mouse/scroll/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func main() {

--- a/examples/windows/multiple/main.go
+++ b/examples/windows/multiple/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/jacekolszak/pixiq/decoder"
-	"github.com/jacekolszak/pixiq/glblend"
-	"github.com/jacekolszak/pixiq/glfw"
 	"log"
+
+	"github.com/elgopher/pixiq/decoder"
+	"github.com/elgopher/pixiq/glblend"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 // This example shows how to open two windows at the same time.

--- a/examples/windows/multiplegl/main.go
+++ b/examples/windows/multiplegl/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log"
 
-	"github.com/jacekolszak/pixiq/colornames"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/colornames"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 // This example shows how too use two separate OpenGL instances. Each contains its

--- a/gl/command.go
+++ b/gl/command.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // Command is a procedure drawing primitives (such as triangles) in the AcceleratedImage.

--- a/gl/context.go
+++ b/gl/context.go
@@ -3,7 +3,7 @@ package gl
 import (
 	"fmt"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // Context is an abstraction for OpenGL context which greatly simplifies

--- a/gl/gl.go
+++ b/gl/gl.go
@@ -9,7 +9,7 @@
 package gl
 
 import (
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // NewContext returns an OpenGL's Context for given API.

--- a/gl/gl_test.go
+++ b/gl/gl_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/image"
 )
 
 func TestNewContext(t *testing.T) {

--- a/gl/image.go
+++ b/gl/image.go
@@ -3,7 +3,7 @@ package gl
 import (
 	"fmt"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // NewAcceleratedImage returns an OpenGL-accelerated implementation of image.AcceleratedImage

--- a/gl/integration/glfw/opengl_bench_test.go
+++ b/gl/integration/glfw/opengl_bench_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 func BenchmarkAcceleratedImage_Upload(b *testing.B) {

--- a/gl/integration/glfw/opengl_integration_test.go
+++ b/gl/integration/glfw/opengl_integration_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 var mainThreadLoop *glfw.MainThreadLoop

--- a/gl/integration/glfw/opengl_nvidia_test.go
+++ b/gl/integration/glfw/opengl_nvidia_test.go
@@ -1,3 +1,4 @@
+//go:build nvidia
 // +build nvidia
 
 package glfw_test
@@ -5,12 +6,12 @@ package glfw_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/gl"
+	"github.com/elgopher/pixiq/gl"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 func TestContext_Error_Nvidia(t *testing.T) {

--- a/glblend/glblend.go
+++ b/glblend/glblend.go
@@ -3,8 +3,8 @@
 package glblend
 
 import (
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/image"
 )
 
 // NewSource creates a new blending tool which replaces target selection with source

--- a/glblend/glblend_test.go
+++ b/glblend/glblend_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/glblend"
+	"github.com/elgopher/pixiq/glblend"
 )
 
 func TestNewSource(t *testing.T) {

--- a/glblend/integration/glfw/integration_bench_test.go
+++ b/glblend/integration/glfw/integration_bench_test.go
@@ -3,9 +3,9 @@ package glfw_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/glblend"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/glblend"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 var resolutions = map[string]struct {

--- a/glblend/integration/glfw/integration_test.go
+++ b/glblend/integration/glfw/integration_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/glblend"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/glblend"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 var mainThreadLoop *glfw.MainThreadLoop

--- a/glclear/glclear.go
+++ b/glclear/glclear.go
@@ -3,8 +3,8 @@
 package glclear
 
 import (
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/image"
 )
 
 // glContext is an OpenGL context. Possible implementation is *gl.Context which can be

--- a/glclear/glclear_integration_test.go
+++ b/glclear/glclear_integration_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glclear"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/glclear"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
 )
 
 var mainThreadLoop *glfw.MainThreadLoop

--- a/glclear/glclear_test.go
+++ b/glclear/glclear_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glclear"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glclear"
 )
 
 func TestNew(t *testing.T) {

--- a/glfw/gl_api_bench_test.go
+++ b/glfw/gl_api_bench_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 // Must be at most 1 allocs/op

--- a/glfw/glfw.go
+++ b/glfw/glfw.go
@@ -11,9 +11,9 @@ import (
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/goimage"
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/goimage"
+	"github.com/elgopher/pixiq/image"
 )
 
 // NewOpenGL creates OpenGL instance.

--- a/glfw/glfw_test.go
+++ b/glfw/glfw_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 var mainThreadLoop *glfw.MainThreadLoop

--- a/glfw/internal/keyboard.go
+++ b/glfw/internal/keyboard.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 // KeyboardEvents maps GLFW events to keyboard.Event. Mapped events can be

--- a/glfw/internal/keyboard_test.go
+++ b/glfw/internal/keyboard_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw/internal"
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/glfw/internal"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func TestNewKeyboardEvents(t *testing.T) {

--- a/glfw/internal/keymap.go
+++ b/glfw/internal/keymap.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 var keymap = map[glfw.Key]keyboard.Key{

--- a/glfw/internal/mouse.go
+++ b/glfw/internal/mouse.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 // MouseEvents maps GLFW events to mouse.Event. Mapped events can be

--- a/glfw/internal/mouse_test.go
+++ b/glfw/internal/mouse_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw/internal"
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/glfw/internal"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func TestNewMouseEvents(t *testing.T) {

--- a/glfw/polygons.go
+++ b/glfw/polygons.go
@@ -3,7 +3,7 @@ package glfw
 import (
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
 
-	"github.com/jacekolszak/pixiq/gl"
+	"github.com/elgopher/pixiq/gl"
 )
 
 func newScreenPolygon(context *gl.Context) *screenPolygon {

--- a/glfw/program.go
+++ b/glfw/program.go
@@ -1,7 +1,7 @@
 package glfw
 
 import (
-	"github.com/jacekolszak/pixiq/gl"
+	"github.com/elgopher/pixiq/gl"
 )
 
 func compileProgram(context *gl.Context, vertexShaderSrc, fragmentShaderSrc string) (*gl.Program, error) {

--- a/glfw/window.go
+++ b/glfw/window.go
@@ -3,13 +3,13 @@ package glfw
 import (
 	"log"
 
+	"github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glfw/internal"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/keyboard"
+	"github.com/elgopher/pixiq/mouse"
 	gl33 "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
-	"github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw/internal"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/keyboard"
-	"github.com/jacekolszak/pixiq/mouse"
 )
 
 // Window is an implementation of loop.Screen and keyboard.EventSource

--- a/glfw/window_bench_test.go
+++ b/glfw/window_bench_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/glfw"
+	"github.com/elgopher/pixiq/glfw"
 )
 
 func BenchmarkWindow_Draw(b *testing.B) {

--- a/glfw/window_test.go
+++ b/glfw/window_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	gl2 "github.com/jacekolszak/pixiq/gl"
-	"github.com/jacekolszak/pixiq/glfw"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/keyboard"
-	"github.com/jacekolszak/pixiq/mouse"
+	gl2 "github.com/elgopher/pixiq/gl"
+	"github.com/elgopher/pixiq/glfw"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/keyboard"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func TestWindow_DrawIntoBackBuffer(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jacekolszak/pixiq
+module github.com/elgopher/pixiq
 
 go 1.14
 

--- a/goimage/goimage.go
+++ b/goimage/goimage.go
@@ -7,7 +7,7 @@ import (
 	"image/color"
 	"image/draw"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // FromSelection creates a standard Go Image from Pixiq image.Selection

--- a/goimage/goimage_test.go
+++ b/goimage/goimage_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/goimage"
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/goimage"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func TestFromSelection(t *testing.T) {

--- a/image/color_bench_test.go
+++ b/image/color_bench_test.go
@@ -3,7 +3,7 @@ package image_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 func BenchmarkRGBAi(b *testing.B) {

--- a/image/color_test.go
+++ b/image/color_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 func TestRGBA(t *testing.T) {

--- a/image/fake/fake.go
+++ b/image/fake/fake.go
@@ -3,7 +3,7 @@
 package fake
 
 import (
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 // NewAcceleratedImage returns a new instance of *AcceleratedImage which can be

--- a/image/fake/fake_test.go
+++ b/image/fake/fake_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 func TestNewAcceleratedImage(t *testing.T) {

--- a/image/image_bench_test.go
+++ b/image/image_bench_test.go
@@ -3,7 +3,7 @@ package image_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/image"
+	"github.com/elgopher/pixiq/image"
 )
 
 func BenchmarkSelection_SetColor(b *testing.B) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/image"
-	"github.com/jacekolszak/pixiq/image/fake"
+	"github.com/elgopher/pixiq/image"
+	"github.com/elgopher/pixiq/image/fake"
 )
 
 var transparent = image.RGBA(0, 0, 0, 0)

--- a/keyboard/event_buffer_bench_test.go
+++ b/keyboard/event_buffer_bench_test.go
@@ -3,7 +3,7 @@ package keyboard_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 // Should be 0 allocs/op

--- a/keyboard/event_buffer_test.go
+++ b/keyboard/event_buffer_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func TestNewEventBuffer(t *testing.T) {

--- a/keyboard/keyboard_bench_test.go
+++ b/keyboard/keyboard_bench_test.go
@@ -3,7 +3,7 @@ package keyboard_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func BenchmarkKeyboard_Update(b *testing.B) {

--- a/keyboard/keyboard_test.go
+++ b/keyboard/keyboard_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jacekolszak/pixiq/keyboard"
+	"github.com/elgopher/pixiq/keyboard"
 )
 
 func TestNew(t *testing.T) {

--- a/mouse/event_buffer_bench_test.go
+++ b/mouse/event_buffer_bench_test.go
@@ -3,7 +3,7 @@ package mouse_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 // Should be 0 allocs/op

--- a/mouse/event_buffer_test.go
+++ b/mouse/event_buffer_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func TestNewEventBuffer(t *testing.T) {

--- a/mouse/mouse_bench_test.go
+++ b/mouse/mouse_bench_test.go
@@ -3,7 +3,7 @@ package mouse_test
 import (
 	"testing"
 
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func BenchmarkMouse_Update(b *testing.B) {

--- a/mouse/mouse_test.go
+++ b/mouse/mouse_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jacekolszak/pixiq/mouse"
+	"github.com/elgopher/pixiq/mouse"
 )
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
Recently Github user name jacekolszak was changed to elgopher. Change the Go module accordingly. From `github.com/jacekolszak/pixiq` to `github.com/elgopher/pixiq`